### PR TITLE
design: 제출내용, 지원현황 카드 컴포넌트 UI 구현

### DIFF
--- a/src/app/api/forms/[formId]/applications/route.ts
+++ b/src/app/api/forms/[formId]/applications/route.ts
@@ -46,6 +46,7 @@ export async function GET(req: NextRequest, { params }: { params: { formId: stri
       page: searchParams.get("page"),
       limit: searchParams.get("limit"),
       status: searchParams.get("status"),
+      sort: searchParams.get("sort"),
     };
 
     const response = await apiClient.get(`/forms/${params.formId}/applications`, {

--- a/src/app/components/button/default/BookmarkBtn.tsx
+++ b/src/app/components/button/default/BookmarkBtn.tsx
@@ -7,7 +7,7 @@ interface BookmarkBtnProps {
   className?: string;
 }
 
-const BookmarkBtn: React.FC<BookmarkBtnProps> = ({ className = "" }) => {
+const BookmarkBtn = ({ className = "" }: BookmarkBtnProps) => {
   const [isBookmarked, setIsBookmarked] = useState(false);
 
   const toggleBookmark = () => {

--- a/src/app/components/button/default/Button.tsx
+++ b/src/app/components/button/default/Button.tsx
@@ -21,7 +21,7 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  * @param props - 추가 버튼 속성
  * @returns 버튼 컴포넌트
  */
-const Button: React.FC<ButtonProps> = ({
+const Button = ({
   className = "",
   variant = "solid",
   width = "md",
@@ -31,7 +31,7 @@ const Button: React.FC<ButtonProps> = ({
   disabled = false,
   children,
   ...props
-}) => {
+}: ButtonProps) => {
   const baseStyles = "inline-flex items-center justify-center transition-colors font-medium h-12";
 
   const colorStyles = {

--- a/src/app/components/button/default/CheckBtn.tsx
+++ b/src/app/components/button/default/CheckBtn.tsx
@@ -11,15 +11,7 @@ interface CheckBtnProps extends InputHTMLAttributes<HTMLInputElement> {
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-const CheckBtn: React.FC<CheckBtnProps> = ({
-  label,
-  name,
-  value,
-  checked = false,
-  disabled = false,
-  onChange,
-  ...props
-}) => {
+const CheckBtn = ({ label, name, value, checked = false, disabled = false, onChange, ...props }: CheckBtnProps) => {
   return (
     <div
       className={cn(

--- a/src/app/components/button/default/FloatingBtn.tsx
+++ b/src/app/components/button/default/FloatingBtn.tsx
@@ -7,7 +7,7 @@ interface FloatingBtnProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   icon?: ReactNode;
 }
 
-const FloatingBtn: React.FC<FloatingBtnProps> = ({ variant = "orange", icon, children, className, ...props }) => {
+const FloatingBtn = ({ variant = "orange", icon, children, className, ...props }: FloatingBtnProps) => {
   const baseStyles = "inline-flex items-center justify-center transition-colors font-medium rounded-full h-12";
 
   const variants = {

--- a/src/app/components/button/default/FrameRadioBtn.tsx
+++ b/src/app/components/button/default/FrameRadioBtn.tsx
@@ -12,7 +12,7 @@ interface FrameRadioBtnProps extends ButtonHTMLAttributes<HTMLInputElement> {
   disabled?: boolean; // 라디오 버튼이 비활성화된 상태인지 여부
 }
 
-const FrameRadioBtn: React.FC<FrameRadioBtnProps> = ({ width = "sm", checked = false, disabled = false, ...props }) => {
+const FrameRadioBtn = ({ width = "sm", checked = false, disabled = false, ...props }: FrameRadioBtnProps) => {
   const baseStyles = "flex items-center justify-between rounded-lg border px-5 py-4";
 
   const widths = {

--- a/src/app/components/button/dropdown/FilterDropdown.tsx
+++ b/src/app/components/button/dropdown/FilterDropdown.tsx
@@ -9,7 +9,7 @@ interface FilterDropdownProps {
   className?: string;
 }
 
-const FilterDropdown: React.FC<FilterDropdownProps> = ({ options, className = "" }) => {
+const FilterDropdown = ({ options, className = "" }: FilterDropdownProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedLabel, setSelectedLabel] = useState(options[0]);
 

--- a/src/app/components/button/dropdown/InputDropdown.tsx
+++ b/src/app/components/button/dropdown/InputDropdown.tsx
@@ -7,7 +7,7 @@ interface InputDropdownProps {
   className?: string;
 }
 
-const InputDropdown: React.FC<InputDropdownProps> = ({ options, className = "" }) => {
+const InputDropdown = ({ options, className = "" }: InputDropdownProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [selectedValue, setSelectedValue] = useState<string>("");
   const [isCustomInput, setIsCustomInput] = useState<boolean>(false);

--- a/src/app/components/button/dropdown/SortDropdown.tsx
+++ b/src/app/components/button/dropdown/SortDropdown.tsx
@@ -10,7 +10,7 @@ interface SortProps {
   onSortChange: (option: string) => void;
 }
 
-const SortDropdown: React.FC<SortProps> = ({ label, options, className = "", onSortChange }) => {
+const SortDropdown = ({ label, options, className = "", onSortChange }: SortProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedLabel, setSelectedLabel] = useState(label);
 

--- a/src/app/components/button/dropdown/TopMenuDropdown.tsx
+++ b/src/app/components/button/dropdown/TopMenuDropdown.tsx
@@ -8,7 +8,7 @@ interface TopMenuDropdownProps {
   className?: string;
 }
 
-const TopMenuDropdown: React.FC<TopMenuDropdownProps> = ({ options, className = "" }) => {
+const TopMenuDropdown = ({ options, className = "" }: TopMenuDropdownProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [selectedValue, setSelectedValue] = useState<string>(""); // 선택된 값 (label을 저장)
   const [isCustomInput, setIsCustomInput] = useState<boolean>(false);

--- a/src/app/components/card/cardList/ApplicationStatusCard.tsx
+++ b/src/app/components/card/cardList/ApplicationStatusCard.tsx
@@ -1,9 +1,16 @@
+"use client";
 import React from "react";
 import { FormListType } from "@/types/response/form";
 import { cn } from "@/lib/tailwindUtil";
 import { FaBookmark } from "react-icons/fa6";
 import { MdPeopleAlt } from "react-icons/md";
-const ApplicationStatusCard: React.FC<{ formData: FormListType }> = ({ formData }) => {
+
+interface ApplicationStatusCardProps {
+  formData: FormListType;
+}
+
+// 지원현황 카드 컴포넌트
+const ApplicationStatusCard = ({ formData }: ApplicationStatusCardProps) => {
   const propsStyle = "flex items-center gap-4 md:gap-6";
   const iconStyle = "text-sm md:text-xl";
   const titleStyle = "min-w-[60px] md:min-w-[80px]";

--- a/src/app/components/card/cardList/ApplicationStatusCard.tsx
+++ b/src/app/components/card/cardList/ApplicationStatusCard.tsx
@@ -1,31 +1,78 @@
 "use client";
-import React from "react";
-import { FormListType } from "@/types/response/form";
+import React, { useState } from "react";
+import { ApplicationResponse } from "@/types/response/application";
+import { FaSortAmountDown } from "react-icons/fa";
 import { cn } from "@/lib/tailwindUtil";
-import { FaBookmark } from "react-icons/fa6";
-import { MdPeopleAlt } from "react-icons/md";
-
 interface ApplicationStatusCardProps {
-  formData: FormListType;
+  applications: ApplicationResponse[];
 }
 
 // 지원현황 카드 컴포넌트
-const ApplicationStatusCard = ({ formData }: ApplicationStatusCardProps) => {
-  const propsStyle = "flex items-center gap-4 md:gap-6";
-  const iconStyle = "text-sm md:text-xl";
-  const titleStyle = "min-w-[60px] md:min-w-[80px]";
-  return (
-    <div className="flex w-[327px] flex-col gap-3 rounded-lg border border-line-100 bg-white p-3 text-xs md:w-[770px] md:gap-5 md:px-5 md:py-8 md:text-lg">
-      <div className={cn(propsStyle)}>
-        <FaBookmark className={cn(iconStyle, "text-primary-orange-300")} />
-        <span className={cn(titleStyle)}>스크랩</span>
-        <strong>{formData.scrapCount}개</strong>
-      </div>
+const ApplicationStatusCard = ({ applications }: ApplicationStatusCardProps) => {
+  const [sortOrder, setSortOrder] = useState<{ experience: boolean; status: boolean }>({
+    experience: true, // true: 오름차순, false: 내림차순
+    status: true,
+  });
 
-      <div className={cn(propsStyle)}>
-        <MdPeopleAlt className={cn(iconStyle)} />
-        <span className={cn(titleStyle)}>지원현황</span>
-        <strong>현재까지 {formData.applyCount}명이 알바폼에 지원했어요!</strong>
+  const handleSort = (key: "experience" | "status") => {
+    const newOrder = !sortOrder[key];
+    setSortOrder((prev) => ({ ...prev, [key]: newOrder }));
+  };
+
+  const sortedApplications = [...applications]
+    .sort((a, b) => {
+      if (sortOrder.experience) {
+        return a.experienceMonths - b.experienceMonths; // 경력 오름차순
+      } else {
+        return b.experienceMonths - a.experienceMonths; // 경력 내림차순
+      }
+    })
+    .sort((a, b) => {
+      if (sortOrder.status) {
+        return a.status.localeCompare(b.status); // 상태 오름차순
+      } else {
+        return b.status.localeCompare(a.status); // 상태 내림차순
+      }
+    });
+
+  const theadStyle = "text-left font-semibold text-gray-700";
+  const tbodyStyle = "text-left";
+  const sortIconStyle = "text-primary-orange-300 transition-transform hover:scale-110";
+  return (
+    <div className="w-[375px] text-xs md:w-[770px] md:text-base">
+      <div className="flex flex-col">
+        {/* Thead */}
+        <div className="sticky grid grid-cols-[1fr_2fr_0.6fr_0.6fr] px-6 py-4">
+          <span className={theadStyle}>이름</span>
+          <span className={theadStyle}>전화번호</span>
+          <div className="flex items-center gap-2">
+            <span className={theadStyle}>경력</span>
+            <button onClick={() => handleSort("experience")}>
+              <FaSortAmountDown className={cn(sortIconStyle, sortOrder.experience ? "rotate-0" : "rotate-180")} />
+            </button>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-left font-semibold text-gray-700">상태</span>
+            <button onClick={() => handleSort("status")}>
+              <FaSortAmountDown className={cn(sortIconStyle, sortOrder.status ? "rotate-0" : "rotate-180")} />
+            </button>
+          </div>
+        </div>
+
+        {/* Tbody */}
+        <div className="scrollbar-custom h-[360px] overflow-y-auto md:h-[400px]">
+          {sortedApplications.map((application) => (
+            <div
+              key={application.id}
+              className="grid grid-cols-[1fr_2fr_0.6fr_0.6fr] border-b border-line-100 px-6 py-4"
+            >
+              <span className={tbodyStyle}>{application.name}</span>
+              <span className={tbodyStyle}>{application.phoneNumber}</span>
+              <span className={tbodyStyle}>{application.experienceMonths}개월</span>
+              <span className={tbodyStyle}>{application.status}</span>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/app/components/card/cardList/CardChipIcon.tsx
+++ b/src/app/components/card/cardList/CardChipIcon.tsx
@@ -1,0 +1,34 @@
+"use client";
+import React from "react";
+import { FormListType } from "@/types/response/form";
+import { cn } from "@/lib/tailwindUtil";
+import { FaBookmark } from "react-icons/fa6";
+import { MdPeopleAlt } from "react-icons/md";
+
+interface CardChipIconProps {
+  formData: FormListType;
+}
+
+// chip icon
+const CardChipIcon = ({ formData }: CardChipIconProps) => {
+  const propsStyle = "flex items-center gap-4 md:gap-6";
+  const iconStyle = "text-sm md:text-xl";
+  const titleStyle = "min-w-[60px] md:min-w-[80px]";
+  return (
+    <div className="flex w-[327px] flex-col gap-3 rounded-lg border border-line-100 bg-white p-3 text-xs md:w-[770px] md:gap-5 md:px-5 md:py-8 md:text-lg">
+      <div className={cn(propsStyle)}>
+        <FaBookmark className={cn(iconStyle, "text-primary-orange-300")} />
+        <span className={cn(titleStyle)}>스크랩</span>
+        <strong>{formData.scrapCount}개</strong>
+      </div>
+
+      <div className={cn(propsStyle)}>
+        <MdPeopleAlt className={cn(iconStyle)} />
+        <span className={cn(titleStyle)}>지원현황</span>
+        <strong>현재까지 {formData.applyCount}명이 알바폼에 지원했어요!</strong>
+      </div>
+    </div>
+  );
+};
+
+export default CardChipIcon;

--- a/src/app/components/card/cardList/RecruitCond.tsx
+++ b/src/app/components/card/cardList/RecruitCond.tsx
@@ -1,8 +1,14 @@
+"use client";
 import React from "react";
 import { FormDetailResponse } from "@/types/response/form";
 import { cn } from "@/lib/tailwindUtil";
 
-const RecruitCond: React.FC<{ recruitData: FormDetailResponse }> = ({ recruitData }) => {
+interface RecruitCondProps {
+  recruitData: FormDetailResponse;
+}
+
+// 모집조건 카드 컴포넌트
+const RecruitCond = ({ recruitData }: RecruitCondProps) => {
   const titleStyle = "text-black-200 min-w-[64px] md:min-w-[120px]";
   return (
     <div className="flex w-[327px] flex-col gap-5 rounded-lg border border-line-100 bg-white p-4 text-xs md:w-[640px] md:p-6 md:text-lg">

--- a/src/app/components/card/cardList/RecruitDetail.tsx
+++ b/src/app/components/card/cardList/RecruitDetail.tsx
@@ -2,10 +2,17 @@ import React from "react";
 import { FormDetailResponse } from "@/types/response/form";
 import { cn } from "@/lib/tailwindUtil";
 
+// 모집상세 카드 컴포넌트
 const Devider = () => <div className="border-b-[1px] border-line-200" />;
-const RecruitDetail: React.FC<{ recruitData: FormDetailResponse }> = ({ recruitData }) => {
+
+interface RecruitDetailProps {
+  recruitData: FormDetailResponse;
+}
+
+const RecruitDetail = ({ recruitData }: RecruitDetailProps) => {
   const titleStyle = "text-black-100";
   const propsStyle = "flex items-center justify-between md:py-4";
+
   return (
     <div className="flex h-[156px] w-[375px] flex-col justify-center gap-3 rounded-lg border border-line-100 bg-white px-6 py-3 text-sm md:h-[336px] md:w-[640px] md:gap-6 md:text-lg">
       <div className={cn(propsStyle)}>

--- a/src/app/components/card/cardList/SubmitContCard.tsx
+++ b/src/app/components/card/cardList/SubmitContCard.tsx
@@ -1,0 +1,27 @@
+"use client";
+import { ApplicationResponse } from "@/types/response/application";
+import React from "react";
+
+interface SubmitContCardProps {
+  submitContData: ApplicationResponse;
+}
+
+// 지원내용 카드 컴포넌트
+const SubmitContCard = ({ submitContData }: SubmitContCardProps) => {
+  return (
+    <div className="rounded border p-4 shadow">
+      <h2 className="text-lg font-bold">지원자 정보</h2>
+      <p>
+        <strong>이름:</strong> {submitContData.name}
+      </p>
+      <p>
+        <strong>연락처:</strong> {submitContData.phoneNumber}
+      </p>
+      <p>
+        <strong>경력:</strong> {submitContData.experienceMonths} 개월
+      </p>
+    </div>
+  );
+};
+
+export default SubmitContCard;

--- a/src/app/components/card/cardList/SubmitContCard.tsx
+++ b/src/app/components/card/cardList/SubmitContCard.tsx
@@ -1,25 +1,35 @@
 "use client";
 import { ApplicationResponse } from "@/types/response/application";
 import React from "react";
+import { cn } from "@/lib/tailwindUtil";
 
 interface SubmitContCardProps {
   submitContData: ApplicationResponse;
 }
 
 // 지원내용 카드 컴포넌트
+const Devider = () => <div className="border-b-[1px] border-line-200" />;
+
 const SubmitContCard = ({ submitContData }: SubmitContCardProps) => {
+  const titleStyle = "text-black-100";
+  const propsStyle = "flex items-center justify-between py-4";
+
   return (
-    <div className="rounded border p-4 shadow">
-      <h2 className="text-lg font-bold">지원자 정보</h2>
-      <p>
-        <strong>이름:</strong> {submitContData.name}
-      </p>
-      <p>
-        <strong>연락처:</strong> {submitContData.phoneNumber}
-      </p>
-      <p>
-        <strong>경력:</strong> {submitContData.experienceMonths} 개월
-      </p>
+    <div className="flex w-[770px] flex-col justify-center gap-4 bg-white px-6 text-base">
+      <div className={cn(propsStyle)}>
+        <span className={cn(titleStyle)}>이름</span>
+        <strong>{submitContData.name}</strong>
+      </div>
+      <Devider />
+      <div className={cn(propsStyle)}>
+        <span className={cn(titleStyle)}>연락처</span>
+        <strong>{submitContData.phoneNumber}</strong>
+      </div>
+      <Devider />
+      <div className={cn(propsStyle)}>
+        <span className={cn(titleStyle)}>경력</span>
+        <strong>{submitContData.experienceMonths} 개월</strong>
+      </div>
     </div>
   );
 };

--- a/src/app/components/card/cardList/SubmitContCard.tsx
+++ b/src/app/components/card/cardList/SubmitContCard.tsx
@@ -7,7 +7,7 @@ interface SubmitContCardProps {
   submitContData: ApplicationResponse;
 }
 
-// 지원내용 카드 컴포넌트
+// 제출내용 카드 컴포넌트
 const Devider = () => <div className="border-b-[1px] border-line-200" />;
 
 const SubmitContCard = ({ submitContData }: SubmitContCardProps) => {

--- a/src/app/components/chip/ChipWithIcon.tsx
+++ b/src/app/components/chip/ChipWithIcon.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { FaBookmark, FaRegBookmark } from "react-icons/fa";
 import Chip from "./Chip";
 

--- a/src/app/components/input/applicantCountInput/ApplicantCountInput.tsx
+++ b/src/app/components/input/applicantCountInput/ApplicantCountInput.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useDropdownOpen } from "@/hooks/useDropdownOpen";
 import BaseInput from "../text/BaseInput";
 import { IoMdArrowDropdown, IoMdArrowDropup } from "react-icons/io";

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -2,10 +2,10 @@
 
 import React, { useEffect } from "react";
 import { Player } from "@lottiefiles/react-lottie-player"; // Lottie 애니메이션 Player
-import { handleError } from "../utils/handleError"; // 유틸리티 함수
-import { getErrorMessage } from "../utils/getErrorMessage"; // 사용자 친화적 메시지
-import { AuthenticationError } from "../types/error";
-import Button from "../app/components/button/Button"; // 버튼 컴포넌트
+import { handleError } from "@/utils/handleError";
+import { AuthenticationError } from "@/types/error";
+import { getErrorMessage } from "@/utils/getErrorMessage";
+import Button from "./components/button/default/Button";
 
 interface GlobalErrorProps {
   error: Error; // 에러 객체 타입

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -167,12 +167,12 @@ input[type="checkbox"]:disabled {
   background: transparent;
 }
 .scrollbar-custom::-webkit-scrollbar-thumb {
-  background: #c4c4c4;
+  background: #fcc369;
   border-radius: 9999px;
 }
 
 .scrollbar-custom::-webkit-scrollbar-thumb:hover {
-  background: #ababab;
+  background: #fbaf37;
 }
 
 /*------------------- date picker 커스텀 --------------------*/

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Link from "next/link";
 import { Player } from "@lottiefiles/react-lottie-player"; // Lottie Player import
-import Button from "../app/components/button/default/Button";
+import Button from "./components/button/default/Button";
 
 export default function NotFound() {
   return (

--- a/src/app/stories/design-system/components/card/cardList/ApplicationStatusCard.stories.tsx
+++ b/src/app/stories/design-system/components/card/cardList/ApplicationStatusCard.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
 import ApplicationStatusCard from "@/app/components/card/cardList/ApplicationStatusCard";
-import { FormListType } from "@/types/response/form";
+import { ApplicationResponse } from "@/types/response/application";
 
 const meta: Meta<typeof ApplicationStatusCard> = {
   title: "Design System/Components/Card/CardList/ApplicationStatusCard",
@@ -13,21 +13,115 @@ const meta: Meta<typeof ApplicationStatusCard> = {
 export default meta;
 type Story = StoryObj<typeof ApplicationStatusCard>;
 
-const mockFormData: FormListType = {
-  updatedAt: new Date(),
-  createdAt: new Date(),
-  isPublic: true,
-  scrapCount: 5,
-  applyCount: 10,
-  imageUrls: ["url1", "url2"],
-  recruitmentEndDate: new Date(),
-  recruitmentStartDate: new Date(),
-  title: "모집 제목",
-  id: 1,
-};
+const mockApplications: ApplicationResponse[] = [
+  {
+    applicantId: 1,
+    updatedAt: new Date(),
+    createdAt: new Date(),
+    status: "submitted",
+    introduction: "안녕하세요, 저는 지원자입니다.",
+    resumeName: "이력서.pdf",
+    resumeId: 123,
+    experienceMonths: 12,
+    phoneNumber: "010-1234-5678",
+    name: "홍길동",
+    id: 1,
+  },
+  {
+    applicantId: 2,
+    updatedAt: new Date(),
+    createdAt: new Date(),
+    status: "interview",
+    introduction: "안녕하세요, 저는 지원자입니다.",
+    resumeName: "이력서2.pdf",
+    resumeId: 124,
+    experienceMonths: 6,
+    phoneNumber: "010-9876-5432",
+    name: "김철수",
+    id: 2,
+  },
+  {
+    applicantId: 3,
+    updatedAt: new Date(),
+    createdAt: new Date(),
+    status: "hired",
+    introduction: "안녕하세요, 저는 지원자입니다.",
+    resumeName: "이력서3.pdf",
+    resumeId: 125,
+    experienceMonths: 24,
+    phoneNumber: "010-1111-2222",
+    name: "이영희",
+    id: 3,
+  },
+  {
+    applicantId: 4,
+    updatedAt: new Date(),
+    createdAt: new Date(),
+    status: "rejected",
+    introduction: "안녕하세요, 저는 지원자입니다.",
+    resumeName: "이력서4.pdf",
+    resumeId: 126,
+    experienceMonths: 3,
+    phoneNumber: "010-2222-3333",
+    name: "박지민",
+    id: 4,
+  },
+  {
+    applicantId: 5,
+    updatedAt: new Date(),
+    createdAt: new Date(),
+    status: "submitted",
+    introduction: "안녕하세요, 저는 지원자입니다.",
+    resumeName: "이력서5.pdf",
+    resumeId: 127,
+    experienceMonths: 18,
+    phoneNumber: "010-4444-5555",
+    name: "최민수",
+    id: 5,
+  },
+  {
+    applicantId: 6,
+    updatedAt: new Date(),
+    createdAt: new Date(),
+    status: "interview",
+    introduction: "안녕하세요, 저는 지원자입니다.",
+    resumeName: "이력서6.pdf",
+    resumeId: 128,
+    experienceMonths: 8,
+    phoneNumber: "010-6666-7777",
+    name: "이수진",
+    id: 6,
+  },
+  {
+    applicantId: 7,
+    updatedAt: new Date(),
+    createdAt: new Date(),
+    status: "hired",
+    introduction: "안녕하세요, 저는 지원자입니다.",
+    resumeName: "이력서7.pdf",
+    resumeId: 129,
+    experienceMonths: 15,
+    phoneNumber: "010-8888-9999",
+    name: "김하늘",
+    id: 7,
+  },
+  {
+    applicantId: 8,
+    updatedAt: new Date(),
+    createdAt: new Date(),
+    status: "rejected",
+    introduction: "안녕하세요, 저는 지원자입니다.",
+    resumeName: "이력서8.pdf",
+    resumeId: 130,
+    experienceMonths: 1,
+    phoneNumber: "010-0000-1111",
+    name: "이정민",
+    id: 8,
+  },
+];
 
 export const Default: Story = {
   args: {
-    formData: mockFormData,
+    applications: mockApplications,
   },
 };

--- a/src/app/stories/design-system/components/card/cardList/CardChipIcon.stories.tsx
+++ b/src/app/stories/design-system/components/card/cardList/CardChipIcon.stories.tsx
@@ -1,0 +1,33 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { FormListType } from "@/types/response/form";
+import CardChipIcon from "@/app/components/card/cardList/CardChipIcon";
+
+const meta: Meta<typeof CardChipIcon> = {
+  title: "Design System/Components/Card/CardList/CardChipIcon",
+  component: CardChipIcon,
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CardChipIcon>;
+
+const mockFormData: FormListType = {
+  updatedAt: new Date(),
+  createdAt: new Date(),
+  isPublic: true,
+  scrapCount: 5,
+  applyCount: 10,
+  imageUrls: ["url1", "url2"],
+  recruitmentEndDate: new Date(),
+  recruitmentStartDate: new Date(),
+  title: "모집 제목",
+  id: 1,
+};
+
+export const Default: Story = {
+  args: {
+    formData: mockFormData,
+  },
+};

--- a/src/app/stories/design-system/components/card/cardList/SubmitContCard.stories.tsx
+++ b/src/app/stories/design-system/components/card/cardList/SubmitContCard.stories.tsx
@@ -1,0 +1,46 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { ApplicationResponse } from "@/types/response/application";
+import SubmitContCard from "@/app/components/card/cardList/SubmitContCard";
+
+const meta: Meta<typeof SubmitContCard> = {
+  title: "Design System/Components/Card/CardList/SubmitContCard",
+  component: SubmitContCard,
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SubmitContCard>;
+
+const mockData: ApplicationResponse = {
+  applicantId: 1,
+  updatedAt: new Date(),
+  createdAt: new Date(),
+  status: "submitted",
+  introduction: "안녕하세요, 저는 지원자입니다.",
+  resumeName: "이력서.pdf",
+  resumeId: 123,
+  experienceMonths: 12,
+  phoneNumber: "010-1234-5678",
+  name: "홍길동",
+  id: 1,
+};
+
+// Default 스토리 정의
+export const Default: Story = {
+  args: {
+    submitContData: mockData,
+  },
+};
+
+// 추가 스토리 정의 가능
+export const Alternative: Story = {
+  args: {
+    submitContData: {
+      ...mockData,
+      name: "김철수", // 다른 이름으로 변경
+      phoneNumber: "010-9876-5432", // 다른 연락처로 변경
+    },
+  },
+};


### PR DESCRIPTION
## 🧑🏻‍💻 작업내용
<img width="653" alt="image" src="https://github.com/user-attachments/assets/6b997b6a-dec4-4bef-8fe7-660739a581f1">

### 카드 2종 추가
- 제출내용 SubmitContCard.tsx
- 지원현황 ApplicationStatusCard.tsx

## 🚧 변경사항
1. global.css 스크롤바 orange색으로 바꿈
2. 'use client' 빠진 파일 추가
3. React.FC 사용된 타입(Props 선언 방식) 제거 -> Props 구조 명시 방식으로 수정

## 📢 전달사항
api 전달했을때 response로 뿌려주는 data를 목업데이터로 만들었는데 나중 페이지 작업할때 수정필요.
response.data 객체를 모두 가져오는데 필요한 데이터만 가져와서 사용할 수 있으면 수정필요.
정렬도 임시로 된 작업이니 페이지 작업시 api에 정렬 기능이 있어 해당 내용으로 수정필요.