### PR TITLE
Design : pagination 컴포넌트 

### DIFF
--- a/src/app/components/input/dateTimeDaypicker/DayPickerBtn.tsx
+++ b/src/app/components/input/dateTimeDaypicker/DayPickerBtn.tsx
@@ -13,13 +13,13 @@ const DayPickerBtn = ({
     onClick(e);
   };
   const defaultStyle = "bg-background-200 text-gray-500";
-  const selectedStyle = "bg-primary-orange-300 text-white";
+  const activeStyle = "bg-primary-orange-300 text-white";
 
   return (
     <div>
       <button
         onClick={handleClick}
-        className={`h-12 w-[38px] rounded-xl bg-background-200 focus:outline-none lg:h-[64px] lg:w-[50px] lg:rounded-2xl ${selected ? selectedStyle : defaultStyle}`}
+        className={`h-12 w-[38px] rounded-xl bg-background-200 focus:outline-none lg:h-[64px] lg:w-[50px] lg:rounded-2xl ${selected ? activeStyle : defaultStyle}`}
       >
         {value}
       </button>

--- a/src/app/components/pagination/Indicator.tsx
+++ b/src/app/components/pagination/Indicator.tsx
@@ -1,14 +1,30 @@
-// 상세폼 이미지 캐러셀 하단 페이지네이션 컴포넌트
+"use client";
+
+import { useState } from "react";
 import { GoDotFill } from "react-icons/go";
 
-const Indicator = ({ imageCount, selectedId }: { imageCount: number; selectedId: number }) => {
+const Indicator = ({ imageCount }: { imageCount: number }) => {
+  // 상세폼 이미지 캐러셀 하단 페이지네이션 컴포넌트
+  const [currentPage, setCurrentPage] = useState<number>(1);
   const activeStyle = "size-4 text-gray-300 opacity-60";
   const defaultStyle = "size-3 text-gray-50 opacity-60";
+
   // 이미지 개수 만큼 동적으로 생성
   const indicators = Array(imageCount)
     .fill(null)
-    .map((_, index) => <GoDotFill key={index} className={selectedId === index ? activeStyle : defaultStyle} />);
-  return <div className="flex items-center justify-between gap-2">{indicators}</div>;
+    .map((_, index) => (
+      <GoDotFill
+        key={index}
+        onClick={() => setCurrentPage(index)}
+        className={currentPage === index ? activeStyle : defaultStyle}
+      />
+    ));
+
+  return (
+    <button type="button" className="flex items-center justify-between gap-2">
+      {indicators}
+    </button>
+  );
 };
 
 export default Indicator;

--- a/src/app/components/pagination/Indicator.tsx
+++ b/src/app/components/pagination/Indicator.tsx
@@ -2,12 +2,12 @@
 import { GoDotFill } from "react-icons/go";
 
 const Indicator = ({ imageCount, selectedId }: { imageCount: number; selectedId: number }) => {
-  const selectedStyle = "size-4 text-gray-300 opacity-60";
-  const notSelectedStyle = "size-3 text-gray-50 opacity-60";
+  const activeStyle = "size-4 text-gray-300 opacity-60";
+  const defaultStyle = "size-3 text-gray-50 opacity-60";
   // 이미지 개수 만큼 동적으로 생성
   const indicators = Array(imageCount)
     .fill(null)
-    .map((_, index) => <GoDotFill key={index} className={selectedId === index ? selectedStyle : notSelectedStyle} />);
+    .map((_, index) => <GoDotFill key={index} className={selectedId === index ? activeStyle : defaultStyle} />);
   return <div className="flex items-center justify-between gap-2">{indicators}</div>;
 };
 

--- a/src/app/components/pagination/Indicator.tsx
+++ b/src/app/components/pagination/Indicator.tsx
@@ -1,0 +1,14 @@
+// 상세폼 이미지 캐러셀 하단 페이지네이션 컴포넌트
+import { GoDotFill } from "react-icons/go";
+
+const Indicator = ({ imageCount, selectedId }: { imageCount: number; selectedId: number }) => {
+  const selectedStyle = "size-4 text-gray-300 opacity-60";
+  const notSelectedStyle = "size-3 text-gray-50 opacity-60";
+  // 이미지 개수 만큼 동적으로 생성
+  const indicators = Array(imageCount)
+    .fill(null)
+    .map((_, index) => <GoDotFill key={index} className={selectedId === index ? selectedStyle : notSelectedStyle} />);
+  return <div className="flex items-center justify-between gap-2">{indicators}</div>;
+};
+
+export default Indicator;

--- a/src/app/components/pagination/Pagination.tsx
+++ b/src/app/components/pagination/Pagination.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import PaginationBtn from "./paginationComponent/PaginationBtn";
 import { IoIosArrowBack, IoIosArrowForward } from "react-icons/io";
 import useWidth from "@/hooks/useWidth";
@@ -9,30 +9,22 @@ import { cn } from "@/lib/tailwindUtil";
 const Pagination = ({ totalPage }: { totalPage: number }) => {
   const { isMobile } = useWidth();
   const [currentPage, setCurrentPage] = useState<number>(1);
-  const [disbled, setDisabled] = useState({
-    prev: false,
-    next: false,
-  });
 
   const maxPageShow = isMobile ? 3 : 5;
-
   const paginationNum = totalPage > maxPageShow ? maxPageShow : totalPage; // 페이지네이션 개수 유지
-
   const initialPageList = Array(paginationNum)
     .fill(null)
     .map((_, index) => index + 1);
-
   const [pageList, setPageList] = useState<number[]>(initialPageList);
 
   const firstPage = pageList?.[0];
   const lastPage = pageList[pageList.length - 1];
 
+  const prevDisabled = firstPage === 1;
+  const nextDisabled = lastPage === totalPage || totalPage <= maxPageShow;
+
   const handleClickPrevBtn = () => {
     if (firstPage === 1) {
-      setDisabled((origin) => ({
-        ...origin,
-        prev: true,
-      }));
       return;
     } else if (firstPage - maxPageShow <= 0) {
       const newPageList = Array(paginationNum)
@@ -46,10 +38,6 @@ const Pagination = ({ totalPage }: { totalPage: number }) => {
 
   const handleClickNetxBtn = () => {
     if (totalPage <= maxPageShow || lastPage === totalPage) {
-      setDisabled((origin) => ({
-        ...origin,
-        next: true,
-      }));
       return;
     } else if (lastPage === totalPage - 1 || lastPage + maxPageShow > totalPage) {
       const newPageList = Array(paginationNum)
@@ -69,18 +57,11 @@ const Pagination = ({ totalPage }: { totalPage: number }) => {
   const activeStyle = "text-black-400 font-semibold";
   const defaultStyle = "text-gray-200 font-medium lg:font-normal";
 
-  useEffect(() => {
-    const newPageList = Array(paginationNum)
-      .fill(null)
-      .map((_, index) => firstPage + index);
-    setPageList(newPageList);
-  }, [isMobile, totalPage, maxPageShow, paginationNum, firstPage]);
-
   return (
     <div className="flex gap-1">
       <li onClick={handleClickPrevBtn}>
-        <PaginationBtn extraStyle="mr-[6px]" disabled={disbled.prev}>
-          <IoIosArrowBack className={cn(disbled.prev ? defaultStyle : activeStyle)} />
+        <PaginationBtn extraStyle="mr-[6px]" disabled={prevDisabled}>
+          <IoIosArrowBack className={cn(prevDisabled ? defaultStyle : activeStyle)} />
         </PaginationBtn>
       </li>
       <ul className="flex gap-1">
@@ -103,8 +84,8 @@ const Pagination = ({ totalPage }: { totalPage: number }) => {
         <></>
       )}
       <li onClick={handleClickNetxBtn}>
-        <PaginationBtn extraStyle="ml-[6px]" disabled={disbled.next}>
-          <IoIosArrowForward className={cn(disbled.next ? "" : activeStyle)} />
+        <PaginationBtn extraStyle="ml-[6px]" disabled={nextDisabled}>
+          <IoIosArrowForward className={cn(nextDisabled ? defaultStyle : activeStyle)} />
         </PaginationBtn>
       </li>
     </div>

--- a/src/app/components/pagination/Pagination.tsx
+++ b/src/app/components/pagination/Pagination.tsx
@@ -8,25 +8,67 @@ import useWidth from "@/hooks/useWidth";
 const Pagination = ({ totalPage }: { totalPage: number }) => {
   const { isMobile } = useWidth();
   const [currentPage, setCurrentPage] = useState<number>(1);
+  const [disbled, setDisabled] = useState({
+    prev: false,
+    next: false,
+  });
+
+  const maxPageShow = isMobile ? 5 : 7;
+
+  const paginationNum = totalPage > maxPageShow ? maxPageShow - 2 : totalPage; // 페이지네이션 개수 유지
+
+  const initialPageList = Array(paginationNum)
+    .fill(null)
+    .map((_, index) => index + 1);
+
+  const [pageList, setPageList] = useState<number[]>(initialPageList);
+
+  const handleChangePage = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  const firstPage = pageList?.[0];
+  const lastPage = pageList[pageList.length - 1];
+
+  const handleClickPrevBtn = () => {
+    if (firstPage === 1) {
+      setDisabled((prev) => ({ ...prev, prev: false }));
+    } else if (firstPage - maxPageShow + 2 <= 0) {
+      const newPageList = Array(paginationNum)
+        .fill(null)
+        .map((_, index) => index + 1);
+      setPageList(newPageList);
+    } else {
+      setPageList((prev) => prev.map((page) => page - maxPageShow + 2));
+    }
+    console.log(pageList);
+  };
+
+  const handleClickNetxBtn = () => {
+    if (lastPage + maxPageShow - 2 <= totalPage) {
+      setPageList((prev) => prev.map((page) => page + maxPageShow - 2));
+    } else {
+      setPageList((prev) => prev.map((page) => page + totalPage - lastPage - 1));
+      setDisabled((prev) => ({
+        ...prev,
+        next: true,
+      }));
+    }
+    console.log(pageList);
+  };
 
   const activeStyle = "text-black-400 font-semibold";
   const defaultStyle = "text-gray-200 font-medium lg:font-normal";
 
-  const maxPageShow = isMobile ? 5 : 7;
-  const paginationNum = totalPage > maxPageShow ? maxPageShow - 2 : totalPage; // 페이지네이션 개수 유지
-  const pageList = Array(paginationNum)
-    .fill(null)
-    .map((_, index) => index + 1);
-  const handleChangePage = (page: number) => {
-    setCurrentPage(page);
-  };
   return (
     <div className="flex gap-1">
-      <PaginationBtn extraStyle="mr-[6px]">
-        <IoIosArrowBack />
-      </PaginationBtn>
+      <li onClick={handleClickPrevBtn}>
+        <PaginationBtn extraStyle="mr-[6px]">
+          <IoIosArrowBack />
+        </PaginationBtn>
+      </li>
       <ul className="flex gap-1">
-        {pageList.map((page) => (
+        {initialPageList.map((page) => (
           <li key={page} onClick={() => handleChangePage(page)}>
             <PaginationBtn>{page}</PaginationBtn>
           </li>
@@ -44,7 +86,7 @@ const Pagination = ({ totalPage }: { totalPage: number }) => {
       ) : (
         <></>
       )}
-      <li>
+      <li onClick={handleClickNetxBtn}>
         <PaginationBtn extraStyle="ml-[6px]">
           <IoIosArrowForward />
         </PaginationBtn>

--- a/src/app/components/pagination/Pagination.tsx
+++ b/src/app/components/pagination/Pagination.tsx
@@ -19,7 +19,6 @@ const Pagination = ({ totalPage }: { totalPage: number }) => {
     .map((_, index) => index + 1);
   const handleChangePage = (page: number) => {
     setCurrentPage(page);
-    console.log(page);
   };
   return (
     <div className="flex gap-1">

--- a/src/app/components/pagination/Pagination.tsx
+++ b/src/app/components/pagination/Pagination.tsx
@@ -1,45 +1,55 @@
 "use client";
 
+import { useState } from "react";
 import PaginationBtn from "./paginationComponent/PaginationBtn";
 import { IoIosArrowBack, IoIosArrowForward } from "react-icons/io";
+import useWidth from "@/hooks/useWidth";
 
 const Pagination = ({ totalPage }: { totalPage: number }) => {
+  const { isMobile } = useWidth();
+  const [currentPage, setCurrentPage] = useState<number>(1);
+
   const activeStyle = "text-black-400 font-semibold";
   const defaultStyle = "text-gray-200 font-medium lg:font-normal";
 
-  let isMobile;
-  const maxPage = isMobile ? 3 : 5;
-  const paginationNum = totalPage > maxPage ? maxPage : totalPage;
+  const maxPageShow = isMobile ? 5 : 7;
+  const paginationNum = totalPage > maxPageShow ? maxPageShow - 2 : totalPage; // 페이지네이션 개수 유지
   const pageList = Array(paginationNum)
     .fill(null)
     .map((_, index) => index + 1);
-
+  const handleChangePage = (page: number) => {
+    setCurrentPage(page);
+    console.log(page);
+  };
   return (
     <div className="flex gap-1">
-      <div className="mr-[6px]">
-        <PaginationBtn>
-          <IoIosArrowBack />
-        </PaginationBtn>
-      </div>
-      <div className="flex gap-1">
+      <PaginationBtn extraStyle="mr-[6px]">
+        <IoIosArrowBack />
+      </PaginationBtn>
+      <ul className="flex gap-1">
         {pageList.map((page) => (
-          <PaginationBtn key={page}>{page}</PaginationBtn>
+          <li key={page} onClick={() => handleChangePage(page)}>
+            <PaginationBtn>{page}</PaginationBtn>
+          </li>
         ))}
-      </div>
-      {/* ... 마지막 페이지 추가 */}
-      {totalPage > maxPage ? (
+      </ul>
+      {totalPage > maxPageShow ? (
         <>
-          <PaginationBtn> ... </PaginationBtn>
-          <PaginationBtn> {totalPage} </PaginationBtn>
+          <li className="cursor-none">
+            <PaginationBtn> ... </PaginationBtn>
+          </li>
+          <li key={totalPage} onClick={() => handleChangePage(totalPage)}>
+            <PaginationBtn> {totalPage} </PaginationBtn>
+          </li>
         </>
       ) : (
         <></>
       )}
-      <div className="ml-[6px]">
-        <PaginationBtn>
+      <li>
+        <PaginationBtn extraStyle="ml-[6px]">
           <IoIosArrowForward />
         </PaginationBtn>
-      </div>
+      </li>
     </div>
   );
 };

--- a/src/app/components/pagination/Pagination.tsx
+++ b/src/app/components/pagination/Pagination.tsx
@@ -1,21 +1,21 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import PaginationBtn from "./paginationComponent/PaginationBtn";
 import { IoIosArrowBack, IoIosArrowForward } from "react-icons/io";
 import useWidth from "@/hooks/useWidth";
 
 const Pagination = ({ totalPage }: { totalPage: number }) => {
-  const { isMobile } = useWidth();
+  const { isMobile, width } = useWidth();
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [disbled, setDisabled] = useState({
     prev: false,
     next: false,
   });
 
-  const maxPageShow = isMobile ? 5 : 7;
+  const maxPageShow = isMobile ? 3 : 5;
 
-  const paginationNum = totalPage > maxPageShow ? maxPageShow - 2 : totalPage; // 페이지네이션 개수 유지
+  const paginationNum = totalPage > maxPageShow ? maxPageShow : totalPage; // 페이지네이션 개수 유지
 
   const initialPageList = Array(paginationNum)
     .fill(null)
@@ -23,32 +23,32 @@ const Pagination = ({ totalPage }: { totalPage: number }) => {
 
   const [pageList, setPageList] = useState<number[]>(initialPageList);
 
-  const handleChangePage = (page: number) => {
-    setCurrentPage(page);
-  };
-
   const firstPage = pageList?.[0];
   const lastPage = pageList[pageList.length - 1];
 
   const handleClickPrevBtn = () => {
     if (firstPage === 1) {
-      setDisabled((prev) => ({ ...prev, prev: false }));
-    } else if (firstPage - maxPageShow + 2 <= 0) {
+      return;
+    } else if (firstPage - maxPageShow <= 0) {
       const newPageList = Array(paginationNum)
         .fill(null)
         .map((_, index) => index + 1);
       setPageList(newPageList);
     } else {
-      setPageList((prev) => prev.map((page) => page - maxPageShow + 2));
+      setPageList((prev) => prev.map((page) => page - maxPageShow));
     }
-    console.log(pageList);
   };
 
   const handleClickNetxBtn = () => {
-    if (lastPage + maxPageShow - 2 <= totalPage) {
-      setPageList((prev) => prev.map((page) => page + maxPageShow - 2));
+    if (totalPage <= maxPageShow || lastPage === totalPage) {
+      return;
+    } else if (lastPage === totalPage - 1 || lastPage + maxPageShow > totalPage) {
+      const newPageList = Array(paginationNum)
+        .fill(null)
+        .map((_, index) => totalPage - maxPageShow + 1 + index);
+      setPageList(newPageList);
     } else {
-      setPageList((prev) => prev.map((page) => page + totalPage - lastPage - 1));
+      setPageList((prev) => prev.map((page) => page + maxPageShow));
       setDisabled((prev) => ({
         ...prev,
         next: true,
@@ -57,9 +57,22 @@ const Pagination = ({ totalPage }: { totalPage: number }) => {
     console.log(pageList);
   };
 
+  const handleChangePage = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  // extraStyle로 전달
   const activeStyle = "text-black-400 font-semibold";
   const defaultStyle = "text-gray-200 font-medium lg:font-normal";
 
+  useEffect(() => {
+    const newPageList = Array(paginationNum)
+      .fill(null)
+      .map((_, index) => firstPage + index);
+    setPageList(newPageList);
+  }, [isMobile, totalPage, maxPageShow, paginationNum]);
+
+  // disabled/active 스타일
   return (
     <div className="flex gap-1">
       <li onClick={handleClickPrevBtn}>
@@ -68,13 +81,13 @@ const Pagination = ({ totalPage }: { totalPage: number }) => {
         </PaginationBtn>
       </li>
       <ul className="flex gap-1">
-        {initialPageList.map((page) => (
+        {pageList.map((page) => (
           <li key={page} onClick={() => handleChangePage(page)}>
             <PaginationBtn>{page}</PaginationBtn>
           </li>
         ))}
       </ul>
-      {totalPage > maxPageShow ? (
+      {totalPage > maxPageShow + 2 && lastPage < totalPage - 1 ? (
         <>
           <li className="cursor-none">
             <PaginationBtn> ... </PaginationBtn>

--- a/src/app/components/pagination/Pagination.tsx
+++ b/src/app/components/pagination/Pagination.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import PaginationBtn from "./paginationComponent/PaginationBtn";
+import { IoIosArrowBack, IoIosArrowForward } from "react-icons/io";
+
+const Pagination = ({ totalPage }: { totalPage: number }) => {
+  const activeStyle = "text-black-400 font-semibold";
+  const defaultStyle = "text-gray-200 font-medium lg:font-normal";
+
+  let isMobile;
+  const maxPage = isMobile ? 3 : 5;
+  const paginationNum = totalPage > maxPage ? maxPage : totalPage;
+  const pageList = Array(paginationNum)
+    .fill(null)
+    .map((_, index) => index + 1);
+
+  return (
+    <div className="flex gap-1">
+      <div className="mr-[6px]">
+        <PaginationBtn>
+          <IoIosArrowBack />
+        </PaginationBtn>
+      </div>
+      <div className="flex gap-1">
+        {pageList.map((page) => (
+          <PaginationBtn key={page}>{page}</PaginationBtn>
+        ))}
+      </div>
+      {/* ... 마지막 페이지 추가 */}
+      {totalPage > maxPage ? (
+        <>
+          <PaginationBtn> ... </PaginationBtn>
+          <PaginationBtn> {totalPage} </PaginationBtn>
+        </>
+      ) : (
+        <></>
+      )}
+      <div className="ml-[6px]">
+        <PaginationBtn>
+          <IoIosArrowForward />
+        </PaginationBtn>
+      </div>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/src/app/components/pagination/Pagination.tsx
+++ b/src/app/components/pagination/Pagination.tsx
@@ -4,9 +4,10 @@ import { useEffect, useState } from "react";
 import PaginationBtn from "./paginationComponent/PaginationBtn";
 import { IoIosArrowBack, IoIosArrowForward } from "react-icons/io";
 import useWidth from "@/hooks/useWidth";
+import { cn } from "@/lib/tailwindUtil";
 
 const Pagination = ({ totalPage }: { totalPage: number }) => {
-  const { isMobile, width } = useWidth();
+  const { isMobile } = useWidth();
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [disbled, setDisabled] = useState({
     prev: false,
@@ -28,6 +29,10 @@ const Pagination = ({ totalPage }: { totalPage: number }) => {
 
   const handleClickPrevBtn = () => {
     if (firstPage === 1) {
+      setDisabled((origin) => ({
+        ...origin,
+        prev: true,
+      }));
       return;
     } else if (firstPage - maxPageShow <= 0) {
       const newPageList = Array(paginationNum)
@@ -41,6 +46,10 @@ const Pagination = ({ totalPage }: { totalPage: number }) => {
 
   const handleClickNetxBtn = () => {
     if (totalPage <= maxPageShow || lastPage === totalPage) {
+      setDisabled((origin) => ({
+        ...origin,
+        next: true,
+      }));
       return;
     } else if (lastPage === totalPage - 1 || lastPage + maxPageShow > totalPage) {
       const newPageList = Array(paginationNum)
@@ -49,12 +58,7 @@ const Pagination = ({ totalPage }: { totalPage: number }) => {
       setPageList(newPageList);
     } else {
       setPageList((prev) => prev.map((page) => page + maxPageShow));
-      setDisabled((prev) => ({
-        ...prev,
-        next: true,
-      }));
     }
-    console.log(pageList);
   };
 
   const handleChangePage = (page: number) => {
@@ -70,38 +74,37 @@ const Pagination = ({ totalPage }: { totalPage: number }) => {
       .fill(null)
       .map((_, index) => firstPage + index);
     setPageList(newPageList);
-  }, [isMobile, totalPage, maxPageShow, paginationNum]);
+  }, [isMobile, totalPage, maxPageShow, paginationNum, firstPage]);
 
-  // disabled/active 스타일
   return (
     <div className="flex gap-1">
       <li onClick={handleClickPrevBtn}>
-        <PaginationBtn extraStyle="mr-[6px]">
-          <IoIosArrowBack />
+        <PaginationBtn extraStyle="mr-[6px]" disabled={disbled.prev}>
+          <IoIosArrowBack className={cn(disbled.prev ? defaultStyle : activeStyle)} />
         </PaginationBtn>
       </li>
       <ul className="flex gap-1">
         {pageList.map((page) => (
           <li key={page} onClick={() => handleChangePage(page)}>
-            <PaginationBtn>{page}</PaginationBtn>
+            <PaginationBtn extraStyle={page === currentPage ? activeStyle : ""}>{page}</PaginationBtn>
           </li>
         ))}
       </ul>
       {totalPage > maxPageShow + 2 && lastPage < totalPage - 1 ? (
         <>
-          <li className="cursor-none">
+          <li>
             <PaginationBtn> ... </PaginationBtn>
           </li>
           <li key={totalPage} onClick={() => handleChangePage(totalPage)}>
-            <PaginationBtn> {totalPage} </PaginationBtn>
+            <PaginationBtn extraStyle={totalPage === currentPage ? activeStyle : ""}> {totalPage} </PaginationBtn>
           </li>
         </>
       ) : (
         <></>
       )}
       <li onClick={handleClickNetxBtn}>
-        <PaginationBtn extraStyle="ml-[6px]">
-          <IoIosArrowForward />
+        <PaginationBtn extraStyle="ml-[6px]" disabled={disbled.next}>
+          <IoIosArrowForward className={cn(disbled.next ? "" : activeStyle)} />
         </PaginationBtn>
       </li>
     </div>

--- a/src/app/components/pagination/PaginationBtn.tsx
+++ b/src/app/components/pagination/PaginationBtn.tsx
@@ -1,9 +1,0 @@
-import { ReactNode } from "react";
-
-const PaginationBtn = ({ children }: { children: ReactNode }) => {
-  return (
-    <div className="size-34 lg:radius-lg flex items-center justify-center rounded-md lg:size-[48px]">{children}</div>
-  );
-};
-
-export default PaginationBtn;

--- a/src/app/components/pagination/PaginationBtn.tsx
+++ b/src/app/components/pagination/PaginationBtn.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from "react";
+
+const PaginationBtn = ({ children }: { children: ReactNode }) => {
+  return (
+    <div className="size-34 lg:radius-lg flex items-center justify-center rounded-md lg:size-[48px]">{children}</div>
+  );
+};
+
+export default PaginationBtn;

--- a/src/app/components/pagination/PaginationCard.tsx
+++ b/src/app/components/pagination/PaginationCard.tsx
@@ -1,0 +1,13 @@
+const PaginationCard = ({ imageCount, selectedId }: { imageCount: number; selectedId: number }) => {
+  const selectedStyle = "text-gray-50 font-semibold text-xs leading-[20px]";
+  const notSelectedStyle = "text-gray-100 font-medium text-xs leading-[18px]";
+  return (
+    <div className="flex items-center gap-1 rounded-[100px] bg-[#000] px-[10px] py-[2px] opacity-20 lg:gap-2 lg:px-4 lg:py-2 lg:text-lg lg:leading-[26px]">
+      <span className={selectedStyle}>{selectedId + 1}</span>
+      <span className={notSelectedStyle}>/</span>
+      <span className={notSelectedStyle}>{imageCount}</span>
+    </div>
+  );
+};
+
+export default PaginationCard;

--- a/src/app/components/pagination/PaginationCard.tsx
+++ b/src/app/components/pagination/PaginationCard.tsx
@@ -1,11 +1,11 @@
 const PaginationCard = ({ imageCount, selectedId }: { imageCount: number; selectedId: number }) => {
-  const selectedStyle = "text-gray-50 font-semibold text-xs leading-[20px]";
-  const notSelectedStyle = "text-gray-100 font-medium text-xs leading-[18px]";
+  const activeStyle = "text-gray-50 font-semibold text-xs leading-[20px]";
+  const defaultStyle = "text-gray-100 font-medium text-xs leading-[18px]";
   return (
     <div className="flex items-center gap-1 rounded-[100px] bg-[#000] px-[10px] py-[2px] opacity-20 lg:gap-2 lg:px-4 lg:py-2 lg:text-lg lg:leading-[26px]">
-      <span className={selectedStyle}>{selectedId + 1}</span>
-      <span className={notSelectedStyle}>/</span>
-      <span className={notSelectedStyle}>{imageCount}</span>
+      <span className={activeStyle}>{selectedId + 1}</span>
+      <span className={defaultStyle}>/</span>
+      <span className={defaultStyle}>{imageCount}</span>
     </div>
   );
 };

--- a/src/app/components/pagination/PaginationCard.tsx
+++ b/src/app/components/pagination/PaginationCard.tsx
@@ -1,9 +1,9 @@
 const PaginationCard = ({ imageCount, selectedId }: { imageCount: number; selectedId: number }) => {
-  const activeStyle = "text-gray-50 font-semibold text-xs leading-[20px]";
+  const activeStyle = "text-gray-50 font-semibold leading-[20px]";
   const defaultStyle = "text-gray-200 font-medium lg:font-normal";
 
   return (
-    <div className="flex items-center gap-1 rounded-[100px] bg-[#000] px-[10px] py-[2px] opacity-20 lg:gap-2 lg:px-4 lg:py-2 lg:text-lg lg:leading-[26px]">
+    <div className="flex items-center gap-1 rounded-[100px] bg-[#000] px-[10px] py-[2px] text-xs opacity-20 lg:gap-2 lg:px-4 lg:py-2 lg:text-lg lg:leading-[26px]">
       <span className={activeStyle}>{selectedId + 1}</span>
       <span className={defaultStyle}>/</span>
       <span className={defaultStyle}>{imageCount}</span>

--- a/src/app/components/pagination/PaginationCard.tsx
+++ b/src/app/components/pagination/PaginationCard.tsx
@@ -1,6 +1,7 @@
 const PaginationCard = ({ imageCount, selectedId }: { imageCount: number; selectedId: number }) => {
   const activeStyle = "text-gray-50 font-semibold text-xs leading-[20px]";
-  const defaultStyle = "text-gray-100 font-medium text-xs leading-[18px]";
+  const defaultStyle = "text-gray-200 font-medium lg:font-normal";
+
   return (
     <div className="flex items-center gap-1 rounded-[100px] bg-[#000] px-[10px] py-[2px] opacity-20 lg:gap-2 lg:px-4 lg:py-2 lg:text-lg lg:leading-[26px]">
       <span className={activeStyle}>{selectedId + 1}</span>

--- a/src/app/components/pagination/paginationComponent/PaginationBtn.tsx
+++ b/src/app/components/pagination/paginationComponent/PaginationBtn.tsx
@@ -12,9 +12,10 @@ const PaginationBtn = ({
   const wrapperStyle =
     "size-[34px] lg:radius-lg flex items-center justify-center rounded-md lg:size-[48px] bg-background-200";
   const textStyle = "leading-[24px] lg:text-lg text-sm lg:leading-[26px]";
+  const defaultStyle = "text-gray-200 font-medium lg:font-normal";
 
   return (
-    <button type="button" disabled={disabled} className={cn(wrapperStyle, textStyle, extraStyle)}>
+    <button type="button" disabled={disabled} className={cn(wrapperStyle, textStyle, defaultStyle, extraStyle)}>
       {children}
     </button>
   );

--- a/src/app/components/pagination/paginationComponent/PaginationBtn.tsx
+++ b/src/app/components/pagination/paginationComponent/PaginationBtn.tsx
@@ -1,0 +1,10 @@
+import { cn } from "@/lib/tailwindUtil";
+
+const PaginationBtn = ({ children }: { children: React.ReactNode }) => {
+  const wrapperStyle =
+    "size-[34px] lg:radius-lg flex items-center justify-center rounded-md lg:size-[48px] bg-background-200";
+  const textStyle = "leading-[24px] lg:text-lg text-sm lg:leading-[26px]";
+  return <div className={cn(wrapperStyle, textStyle)}>{children}</div>;
+};
+
+export default PaginationBtn;

--- a/src/app/components/pagination/paginationComponent/PaginationBtn.tsx
+++ b/src/app/components/pagination/paginationComponent/PaginationBtn.tsx
@@ -1,10 +1,15 @@
 import { cn } from "@/lib/tailwindUtil";
 
-const PaginationBtn = ({ children }: { children: React.ReactNode }) => {
+const PaginationBtn = ({ children, extraStyle }: { children: React.ReactNode; extraStyle?: string }) => {
   const wrapperStyle =
     "size-[34px] lg:radius-lg flex items-center justify-center rounded-md lg:size-[48px] bg-background-200";
   const textStyle = "leading-[24px] lg:text-lg text-sm lg:leading-[26px]";
-  return <div className={cn(wrapperStyle, textStyle)}>{children}</div>;
+
+  return (
+    <button type="button" className={cn(wrapperStyle, textStyle, extraStyle)}>
+      {children}
+    </button>
+  );
 };
 
 export default PaginationBtn;

--- a/src/app/components/pagination/paginationComponent/PaginationBtn.tsx
+++ b/src/app/components/pagination/paginationComponent/PaginationBtn.tsx
@@ -1,12 +1,20 @@
 import { cn } from "@/lib/tailwindUtil";
 
-const PaginationBtn = ({ children, extraStyle }: { children: React.ReactNode; extraStyle?: string }) => {
+const PaginationBtn = ({
+  children,
+  extraStyle,
+  disabled,
+}: {
+  children: React.ReactNode;
+  extraStyle?: string;
+  disabled?: boolean;
+}) => {
   const wrapperStyle =
     "size-[34px] lg:radius-lg flex items-center justify-center rounded-md lg:size-[48px] bg-background-200";
   const textStyle = "leading-[24px] lg:text-lg text-sm lg:leading-[26px]";
 
   return (
-    <button type="button" className={cn(wrapperStyle, textStyle, extraStyle)}>
+    <button type="button" disabled={disabled} className={cn(wrapperStyle, textStyle, extraStyle)}>
       {children}
     </button>
   );

--- a/src/app/stories/design-system/components/pagination/Indicator.stories.tsx
+++ b/src/app/stories/design-system/components/pagination/Indicator.stories.tsx
@@ -18,7 +18,4 @@ export const IndicatorForCarousel: Story = {
   args: {
     imageCount: 3,
   },
-  argTypes: {
-    selectedId: { control: "radio", options: [0, 1, 2] },
-  },
 };

--- a/src/app/stories/design-system/components/pagination/Indicator.stories.tsx
+++ b/src/app/stories/design-system/components/pagination/Indicator.stories.tsx
@@ -1,0 +1,24 @@
+import "react-datepicker/dist/react-datepicker.css";
+import { Meta, StoryObj } from "@storybook/react";
+import Indicator from "@/app/components/pagination/Indicator";
+
+const meta = {
+  title: "Design System/Components/Pagination/Indicator",
+  component: Indicator,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof Indicator>;
+
+export default meta;
+
+type Story = StoryObj<typeof Indicator>;
+
+export const IndicatorForCarousel: Story = {
+  args: {
+    imageCount: 3,
+  },
+  argTypes: {
+    selectedId: { control: "radio", options: [0, 1, 2] },
+  },
+};

--- a/src/app/stories/design-system/components/pagination/Pagination.stories.tsx
+++ b/src/app/stories/design-system/components/pagination/Pagination.stories.tsx
@@ -5,8 +5,14 @@ import Pagination from "@/app/components/pagination/Pagination";
 const meta = {
   title: "Design System/Components/Pagination",
   component: Pagination,
+  tags: ["autodocs"],
   parameters: {
     layout: "centered",
+    docs: {
+      description: {
+        component: "윈도우 너비에 따라 최대 페이지네이션 개수가 달라집니다. (mobile : 3 , desktop: 5)",
+      },
+    },
   },
 } satisfies Meta<typeof Pagination>;
 
@@ -16,7 +22,7 @@ type Story = StoryObj<typeof Pagination>;
 
 export const DefaultPagination: Story = {
   args: {
-    totalPage: 3,
+    totalPage: 8,
   },
   argTypes: {
     totalPage: { control: "number" },

--- a/src/app/stories/design-system/components/pagination/Pagination.stories.tsx
+++ b/src/app/stories/design-system/components/pagination/Pagination.stories.tsx
@@ -25,6 +25,6 @@ export const DefaultPagination: Story = {
     totalPage: 8,
   },
   argTypes: {
-    totalPage: { control: "number" },
+    totalPage: { control: "range" },
   },
 };

--- a/src/app/stories/design-system/components/pagination/Pagination.stories.tsx
+++ b/src/app/stories/design-system/components/pagination/Pagination.stories.tsx
@@ -1,0 +1,24 @@
+import "react-datepicker/dist/react-datepicker.css";
+import { Meta, StoryObj } from "@storybook/react";
+import Pagination from "@/app/components/pagination/Pagination";
+
+const meta = {
+  title: "Design System/Components/Pagination",
+  component: Pagination,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof Pagination>;
+
+export default meta;
+
+type Story = StoryObj<typeof Pagination>;
+
+export const DefaultPagination: Story = {
+  args: {
+    totalPage: 3,
+  },
+  argTypes: {
+    totalPage: { control: "number" },
+  },
+};

--- a/src/app/stories/design-system/components/pagination/PaginationCard.stories.tsx
+++ b/src/app/stories/design-system/components/pagination/PaginationCard.stories.tsx
@@ -1,22 +1,23 @@
 import "react-datepicker/dist/react-datepicker.css";
 import { Meta, StoryObj } from "@storybook/react";
-import Indicator from "@/app/components/pagination/Indicator";
+import PaginationCard from "@/app/components/pagination/PaginationCard";
 
 const meta = {
-  title: "Design System/Components/Pagination/IndicatorForCarousel",
-  component: Indicator,
+  title: "Design System/Components/Pagination",
+  component: PaginationCard,
   parameters: {
     layout: "centered",
   },
-} satisfies Meta<typeof Indicator>;
+} satisfies Meta<typeof PaginationCard>;
 
 export default meta;
 
-type Story = StoryObj<typeof Indicator>;
+type Story = StoryObj<typeof PaginationCard>;
 
-export const IndicatorForCarousel: Story = {
+export const Card: Story = {
   args: {
     imageCount: 3,
+    selectedId: 1,
   },
   argTypes: {
     selectedId: { control: "radio", options: [0, 1, 2] },

--- a/src/hooks/useWidth.ts
+++ b/src/hooks/useWidth.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const BREAKPOINTS = {
+  MOBILE: 640,
+  TABLET: 1024,
+};
+
+const useWidth = () => {
+  const [width, setWidth] = useState(window.innerWidth);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWidth(window.innerWidth);
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  const isMobile = width < BREAKPOINTS.MOBILE;
+  const isTablet = width >= BREAKPOINTS.MOBILE && width < BREAKPOINTS.TABLET;
+  const isDesktop = width >= BREAKPOINTS.TABLET;
+
+  return { isMobile, isTablet, isDesktop, width };
+};
+export default useWidth;

--- a/src/hooks/useWidth.ts
+++ b/src/hooks/useWidth.ts
@@ -10,6 +10,9 @@ const BREAKPOINTS = {
 
 const useWidth = () => {
   const [width, setWidth] = useState(window.innerWidth);
+  const isMobile = width < BREAKPOINTS.MOBILE;
+  const isTablet = width >= BREAKPOINTS.MOBILE && width < BREAKPOINTS.TABLET;
+  const isDesktop = width >= BREAKPOINTS.TABLET;
 
   useEffect(() => {
     const handleResize = debounce(() => {
@@ -19,10 +22,6 @@ const useWidth = () => {
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
   }, []);
-
-  const isMobile = width < BREAKPOINTS.MOBILE;
-  const isTablet = width >= BREAKPOINTS.MOBILE && width < BREAKPOINTS.TABLET;
-  const isDesktop = width >= BREAKPOINTS.TABLET;
 
   return { isMobile, isTablet, isDesktop, width };
 };

--- a/src/hooks/useWidth.ts
+++ b/src/hooks/useWidth.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import debounce from "@/utils/debounce";
 import { useEffect, useState } from "react";
 
 const BREAKPOINTS = {
@@ -11,9 +12,9 @@ const useWidth = () => {
   const [width, setWidth] = useState(window.innerWidth);
 
   useEffect(() => {
-    const handleResize = () => {
+    const handleResize = debounce(() => {
       setWidth(window.innerWidth);
-    };
+    }, 100);
 
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,13 @@
+const debounce = (func: any, delay: number) => {
+  let timeoutId: NodeJS.Timeout;
+
+  return (...args: any[]) => {
+    clearTimeout(timeoutId);
+
+    timeoutId = setTimeout(() => {
+      func(...args);
+    }, delay);
+  };
+};
+
+export default debounce;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,6 +21,7 @@ const config: Config = {
           500: "#040404",
         },
         gray: {
+          50: "#F2F2F2",
           100: "#DEDEDE",
           200: "#C4C4C4",
           300: "#ABABAB",


### PR DESCRIPTION
## pagination 관련 컴포넌트 구현
- indicator, card  : 캐러셀 하단 (이미지 참조)
- 일반 pagination : mobile - 3개 / desktop - 5개 페이지씩 불러오도록 설정했습니다.
- 로직이 많이 복잡한것같네요ㅠ 개선점이 있다면 알려주세요
- useWidth - 윈도우 너비에 따른 반응형 구현을 위한 커스텀훅 추가했습니다.
- debounce 함수 추가했습니다.

![image](https://github.com/user-attachments/assets/f5d18cba-0695-45ee-94e6-903af1671963)

- #14 