### PR TITLE
fix: 드롭다운 컴포넌트 더블 클릭시 빈 메뉴가 생기는 현상 수정

### DIFF
--- a/src/app/(pages)/albaList/page.tsx
+++ b/src/app/(pages)/albaList/page.tsx
@@ -108,7 +108,7 @@ export default function AlbaList() {
         <div className="w-full border-b border-line-100">
           <div className="mx-auto flex max-w-screen-xl flex-col gap-4 px-4 py-4 md:px-6 lg:px-8">
             <div className="flex items-center justify-between">
-              <SearchSection />
+              <SearchSection pathname={pathname} />
             </div>
           </div>
         </div>

--- a/src/app/(pages)/albaTalk/page.tsx
+++ b/src/app/(pages)/albaTalk/page.tsx
@@ -74,7 +74,7 @@ export default function AlbaTalk() {
         <div className="w-full border-b border-line-100">
           <div className="mx-auto flex max-w-screen-xl flex-col gap-4 px-4 py-4 md:px-6 lg:px-8">
             <div className="flex items-center justify-between">
-              <SearchSection />
+              <SearchSection pathname={pathname} />
             </div>
           </div>
         </div>

--- a/src/app/(pages)/myAlbaform/(role)/applicant/page.tsx
+++ b/src/app/(pages)/myAlbaform/(role)/applicant/page.tsx
@@ -87,7 +87,7 @@ export default function ApplicantPage() {
         {/* 검색 섹션 */}
         <div className="w-full border-b border-line-100">
           <div className="mx-auto flex max-w-screen-xl flex-col gap-4 px-4 py-4 md:px-6 lg:px-8">
-            <SearchSection />
+            <SearchSection pathname={pathname} />
           </div>
         </div>
 

--- a/src/app/(pages)/myAlbaform/(role)/owner/page.tsx
+++ b/src/app/(pages)/myAlbaform/(role)/owner/page.tsx
@@ -158,7 +158,7 @@ export default function AlbaList() {
         <div className="w-full border-b border-line-100">
           <div className="mx-auto flex max-w-screen-xl flex-col gap-4 px-4 py-4 md:px-6 lg:px-8">
             <div className="flex items-center justify-between">
-              <SearchSection />
+              <SearchSection pathname={pathname} />
             </div>
           </div>
         </div>

--- a/src/app/components/button/dropdown/DropdownList.tsx
+++ b/src/app/components/button/dropdown/DropdownList.tsx
@@ -1,0 +1,90 @@
+"use client";
+import { cn } from "@/lib/tailwindUtil";
+import { useEffect, useRef } from "react";
+
+// 드롭다운 메뉴의 각 항목 컴포넌트
+const DropdownItem = ({
+  item,
+  onSelect,
+  itemStyle,
+}: {
+  item: string;
+  onSelect: (item: string | null) => void;
+  itemStyle?: string;
+}) => {
+  // 항목 클릭 핸들러
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation(); // 이벤트 버블링 방지
+    onSelect(item);
+  };
+
+  return (
+    <li
+      onClick={handleClick}
+      className={cn(
+        "flex w-full cursor-pointer bg-grayscale-50 px-[10px] py-2 text-sm font-normal leading-[18px] text-black-100 hover:bg-primary-orange-50 lg:text-lg lg:leading-[26px]",
+        itemStyle
+      )}
+    >
+      {item}
+    </li>
+  );
+};
+
+// 드롭다운 메뉴 리스트 컴포넌트
+const DropdownList = ({
+  list,
+  onSelect,
+  wrapperStyle,
+  itemStyle,
+}: {
+  list: string[];
+  onSelect: (item: string | null) => void;
+  wrapperStyle?: string;
+  itemStyle?: string;
+}) => {
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // 외부 클릭 감지 및 드롭다운 닫기
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        event.preventDefault();
+        onSelect(null);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside, { capture: true });
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside, { capture: true });
+    };
+  }, [onSelect]);
+
+  // 컨테이너 클릭 이벤트 처리
+  const handleContainerClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <div
+      role="menu"
+      aria-orientation="vertical"
+      aria-labelledby="options-menu"
+      ref={dropdownRef}
+      onClick={handleContainerClick}
+      className={cn(
+        "absolute left-0 right-0 z-10 mt-[6px] rounded border border-grayscale-100 bg-grayscale-50 pr-[2px] pt-1",
+        wrapperStyle
+      )}
+    >
+      <ul className="scrollbar-custom flex max-h-[150px] flex-col">
+        {list.map((item) => (
+          <DropdownItem key={item} item={item} onSelect={onSelect} itemStyle={itemStyle} />
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default DropdownList;

--- a/src/app/components/button/dropdown/FilterDropdown.tsx
+++ b/src/app/components/button/dropdown/FilterDropdown.tsx
@@ -41,10 +41,14 @@ const FilterDropdown = ({ options, className = "", onChange, initialValue, readO
     setIsOpen((prev) => !prev);
   };
 
-  const handleSelect = (option: string) => {
-    setSelectedLabel(option);
-    setIsOpen(false);
-    onChange?.(option);
+  const handleSelect = (option: string | null) => {
+    if (option !== null) {
+      setSelectedLabel(option);
+      setIsOpen(false);
+      onChange?.(option);
+    } else {
+      setIsOpen(false);
+    }
   };
 
   return (
@@ -66,7 +70,10 @@ const FilterDropdown = ({ options, className = "", onChange, initialValue, readO
             ? "border border-grayscale-100 bg-white"
             : "border-primary-orange-300 bg-primary-orange-50"
         )}
-        onClick={toggleDropdown}
+        onClick={(e) => {
+          e.preventDefault();
+          toggleDropdown();
+        }}
         disabled={readOnly}
       >
         <span className={selectedLabel === options[0] ? "text-black-100" : "text-primary-orange-300"}>

--- a/src/app/components/button/dropdown/FilterDropdown.tsx
+++ b/src/app/components/button/dropdown/FilterDropdown.tsx
@@ -12,11 +12,14 @@ interface FilterDropdownProps {
   readOnly?: boolean;
 }
 
+// 필터링 옵션을 선택할 수 있는 드롭다운 컴포넌트
 const FilterDropdown = ({ options, className = "", onChange, initialValue, readOnly = false }: FilterDropdownProps) => {
+  // 드롭다운 상태 관리
   const [isOpen, setIsOpen] = useState(false);
   const [selectedLabel, setSelectedLabel] = useState(initialValue || options[0]);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
+  // 외부 클릭 감지하여 드롭다운 닫기
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
@@ -30,17 +33,20 @@ const FilterDropdown = ({ options, className = "", onChange, initialValue, readO
     };
   }, []);
 
+  // initialValue가 변경되면 선택된 라벨 업데이트
   useEffect(() => {
     if (initialValue) {
       setSelectedLabel(initialValue);
     }
   }, [initialValue]);
 
+  // 드롭다운 토글 핸들러
   const toggleDropdown = () => {
     if (readOnly) return;
     setIsOpen((prev) => !prev);
   };
 
+  // 옵션 선택 핸들러
   const handleSelect = (option: string | null) => {
     if (option !== null) {
       setSelectedLabel(option);

--- a/src/app/components/button/dropdown/InputDropdown.tsx
+++ b/src/app/components/button/dropdown/InputDropdown.tsx
@@ -13,14 +13,17 @@ interface InputDropdownProps {
   value?: string;
 }
 
+// 직접 입력이 가능한 드롭다운 컴포넌트
 const InputDropdown = forwardRef<HTMLInputElement, InputDropdownProps>(
   ({ options, className = "", errormessage, name }, ref) => {
+    // 드롭다운 상태 관리
     const [isOpen, setIsOpen] = useState<boolean>(false);
     const [selectedValue, setSelectedValue] = useState<string>("");
     const [isCustomInput, setIsCustomInput] = useState<boolean>(false);
     const { setValue, watch } = useFormContext();
     const dropdownRef = useRef<HTMLDivElement>(null);
 
+    // 외부 클릭 감지하여 드롭다운 닫기
     useEffect(() => {
       const handleClickOutside = (event: MouseEvent) => {
         if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
@@ -34,11 +37,13 @@ const InputDropdown = forwardRef<HTMLInputElement, InputDropdownProps>(
       };
     }, []);
 
+    // 드롭다운 토글 핸들러
     const toggleDropdown = (e: React.MouseEvent) => {
       e.preventDefault();
       setIsOpen((prev) => !prev);
     };
 
+    // 옵션 선택 핸들러
     const handleSelect = useCallback(
       (option: string | null) => {
         if (!option) {
@@ -62,6 +67,7 @@ const InputDropdown = forwardRef<HTMLInputElement, InputDropdownProps>(
       [name, setValue]
     );
 
+    // 입력값 변경 핸들러
     const handleInputChange = useCallback(
       (e: React.ChangeEvent<HTMLInputElement>) => {
         if (isCustomInput) {
@@ -73,6 +79,18 @@ const InputDropdown = forwardRef<HTMLInputElement, InputDropdownProps>(
       [isCustomInput, name, setValue]
     );
 
+    // 입력 필드 클릭 핸들러
+    const handleInputClick = useCallback(
+      (e: React.MouseEvent) => {
+        e.stopPropagation();
+        if (!isCustomInput) {
+          setIsOpen(true);
+        }
+      },
+      [isCustomInput]
+    );
+
+    // 폼 값 변경 감지하여 입력값 동기화
     useEffect(() => {
       const value = watch(name);
       if (value !== undefined) {
@@ -85,16 +103,6 @@ const InputDropdown = forwardRef<HTMLInputElement, InputDropdownProps>(
     const errorStyle = errormessage ? "!border-state-error" : "";
     const errorTextStyle =
       "absolute -bottom-[26px] text-[13px] text-sm font-medium leading-[22px] text-state-error lg:text-base lg:leading-[26px]";
-
-    const handleInputClick = useCallback(
-      (e: React.MouseEvent) => {
-        e.stopPropagation();
-        if (!isCustomInput) {
-          setIsOpen(true);
-        }
-      },
-      [isCustomInput]
-    );
 
     return (
       <div

--- a/src/app/components/button/dropdown/InputDropdown.tsx
+++ b/src/app/components/button/dropdown/InputDropdown.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { forwardRef, useEffect, useState, useRef } from "react";
+import React, { forwardRef, useEffect, useState, useRef, useCallback } from "react";
 import { IoMdArrowDropdown } from "react-icons/io";
 import { cn } from "@/lib/tailwindUtil";
 import DropdownList from "./dropdownComponent/DropdownList";
@@ -70,6 +70,14 @@ const InputDropdown = forwardRef<HTMLInputElement, InputDropdownProps>(
     const errorTextStyle =
       "absolute -bottom-[26px] text-[13px] text-sm font-medium leading-[22px] text-state-error lg:text-base lg:leading-[26px]";
 
+    const handleInputClick = useCallback(
+      (e: React.MouseEvent) => {
+        e.stopPropagation();
+        setIsOpen(true);
+      },
+      [setIsOpen]
+    );
+
     return (
       <div
         ref={dropdownRef}
@@ -93,7 +101,7 @@ const InputDropdown = forwardRef<HTMLInputElement, InputDropdownProps>(
                 setValue(name, e.target.value);
               }
             }}
-            onClick={(e) => e.stopPropagation()}
+            onClick={handleInputClick}
             className={cn(
               "text-grayscale-700 flex w-full items-center justify-between px-4 py-2 font-medium focus:outline-none",
               "cursor-pointer bg-transparent"

--- a/src/app/components/button/dropdown/dropdownComponent/DropdownList.tsx
+++ b/src/app/components/button/dropdown/dropdownComponent/DropdownList.tsx
@@ -8,12 +8,18 @@ const DropdownItem = ({
   itemStyle,
 }: {
   item: string;
-  onSelect: (item: string) => void;
+  onSelect: (item: string | null) => void;
   itemStyle?: string;
 }) => {
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onSelect(item);
+  };
+
   return (
     <li
-      onClick={() => onSelect(item)}
+      onClick={handleClick}
       className={cn(
         "flex w-full cursor-pointer bg-grayscale-50 px-[10px] py-2 text-sm font-normal leading-[18px] text-black-100 hover:bg-primary-orange-50 lg:text-lg lg:leading-[26px]",
         itemStyle
@@ -23,6 +29,7 @@ const DropdownItem = ({
     </li>
   );
 };
+
 const DropdownList = ({
   list,
   onSelect,
@@ -30,7 +37,7 @@ const DropdownList = ({
   itemStyle,
 }: {
   list: string[];
-  onSelect: (item: string) => void;
+  onSelect: (item: string | null) => void;
   wrapperStyle?: string;
   itemStyle?: string;
 }) => {
@@ -39,15 +46,20 @@ const DropdownList = ({
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        onSelect("");
+        event.preventDefault();
+        onSelect(null);
       }
     };
 
-    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("mousedown", handleClickOutside, { capture: true });
     return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("mousedown", handleClickOutside, { capture: true });
     };
-  }, []);
+  }, [onSelect]);
+
+  const handleContainerClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
 
   return (
     <div
@@ -55,6 +67,7 @@ const DropdownList = ({
       aria-orientation="vertical"
       aria-labelledby="options-menu"
       ref={dropdownRef}
+      onClick={handleContainerClick}
       className={cn(
         "absolute left-0 right-0 z-10 mt-[6px] rounded border border-grayscale-100 bg-grayscale-50 pr-[2px] pt-1",
         wrapperStyle

--- a/src/app/components/input/dateTimeDaypicker/TimePickerInput.tsx
+++ b/src/app/components/input/dateTimeDaypicker/TimePickerInput.tsx
@@ -37,11 +37,15 @@ const TimePickerInput = forwardRef<HTMLInputElement, BaseInputProps>((props, ref
       }
 
       if (onChange) {
-        onChange({ target: { value: time } } as React.ChangeEvent<HTMLInputElement>);
+        const event = {
+          target: { value: time, name: props.name },
+        } as React.ChangeEvent<HTMLInputElement>;
+        onChange(event);
       }
+
       setIsOpen(false);
     },
-    [onChange, setIsOpen]
+    [onChange, props.name, setIsOpen]
   );
 
   const beforeIconStyle = "text-grayscale-400 size-5 lg:size-8";

--- a/src/app/components/input/dateTimeDaypicker/TimePickerInput.tsx
+++ b/src/app/components/input/dateTimeDaypicker/TimePickerInput.tsx
@@ -8,11 +8,13 @@ import { forwardRef, useRef, useEffect, useCallback } from "react";
 import { BaseInputProps } from "@/types/textInput";
 import { cn } from "@/lib/tailwindUtil";
 
+// 시간 선택을 위한 입력 컴포넌트
 const TimePickerInput = forwardRef<HTMLInputElement, BaseInputProps>((props, ref) => {
   const { value, onChange, errormessage } = props;
   const dropdownRef = useRef<HTMLDivElement>(null);
   const { isOpen, handleOpenDropdown, setIsOpen } = useDropdownOpen();
 
+  // 외부 클릭 감지하여 드롭다운 닫기
   const handleClickOutside = useCallback(
     (event: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
@@ -22,6 +24,7 @@ const TimePickerInput = forwardRef<HTMLInputElement, BaseInputProps>((props, ref
     [setIsOpen]
   );
 
+  // 외부 클릭 이벤트 리스너 등록
   useEffect(() => {
     document.addEventListener("mousedown", handleClickOutside);
     return () => {
@@ -29,6 +32,7 @@ const TimePickerInput = forwardRef<HTMLInputElement, BaseInputProps>((props, ref
     };
   }, [handleClickOutside]);
 
+  // 시간 선택 핸들러
   const handleSelect = useCallback(
     (time: string | null) => {
       if (!time) {
@@ -48,15 +52,13 @@ const TimePickerInput = forwardRef<HTMLInputElement, BaseInputProps>((props, ref
     [onChange, props.name, setIsOpen]
   );
 
-  const beforeIconStyle = "text-grayscale-400 size-5 lg:size-8";
-  const afterIconStyle = "text-black-400 size-6 lg:size-9 transition-transform duration-200 ease-in-out";
-  const width = "w-[150px] lg:w-[210px]";
-
+  // 24시간 형식의 시간 옵션 생성 (00:00 ~ 23:00)
   const timeOption = Array.from({ length: 24 }, (_, index) => {
     const hour = index.toString().padStart(2, "0");
     return `${hour}:00`;
   });
 
+  // 클릭 이벤트 핸들러
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
@@ -76,8 +78,15 @@ const TimePickerInput = forwardRef<HTMLInputElement, BaseInputProps>((props, ref
           placeholder="00:00"
           value={value || ""}
           size="w-[150px] h-[54px] lg:w-[210px] lg:h-[64px]"
-          beforeIcon={<LuClock className={beforeIconStyle} strokeWidth="1" />}
-          afterIcon={<IoMdArrowDropup className={cn(afterIconStyle, isOpen && "rotate-180")} />}
+          beforeIcon={<LuClock className="size-5 text-grayscale-400 lg:size-8" strokeWidth="1" />}
+          afterIcon={
+            <IoMdArrowDropup
+              className={cn(
+                "size-6 text-black-400 transition-transform duration-200 lg:size-9",
+                isOpen && "rotate-180"
+              )}
+            />
+          }
           errormessage={errormessage}
         />
       </div>
@@ -85,7 +94,7 @@ const TimePickerInput = forwardRef<HTMLInputElement, BaseInputProps>((props, ref
         <DropdownList
           list={timeOption}
           onSelect={handleSelect}
-          wrapperStyle={width}
+          wrapperStyle="w-[150px] lg:w-[210px]"
           itemStyle="pl-[35px] text-base font-normal leading-[26px] lg:text-lg lg:leading-8"
         />
       )}

--- a/src/app/components/input/dateTimeDaypicker/TimePickerInput.tsx
+++ b/src/app/components/input/dateTimeDaypicker/TimePickerInput.tsx
@@ -4,22 +4,48 @@ import { IoMdArrowDropup } from "react-icons/io";
 import BaseInput from "../text/BaseInput";
 import { useDropdownOpen } from "@/hooks/useDropdownOpen";
 import DropdownList from "../../button/dropdown/dropdownComponent/DropdownList";
-import { forwardRef } from "react";
+import { forwardRef, useRef, useEffect, useCallback } from "react";
 import { BaseInputProps } from "@/types/textInput";
+import { cn } from "@/lib/tailwindUtil";
 
 const TimePickerInput = forwardRef<HTMLInputElement, BaseInputProps>((props, ref) => {
   const { value, onChange, errormessage } = props;
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const { isOpen, handleOpenDropdown, setIsOpen } = useDropdownOpen();
 
-  const handleTimeSelect = (time: string) => {
-    if (onChange) {
-      onChange({ target: { value: time } } as React.ChangeEvent<HTMLInputElement>);
-    }
-    handleOpenDropdown();
-  };
-  const { isOpen, handleOpenDropdown } = useDropdownOpen();
+  const handleClickOutside = useCallback(
+    (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    },
+    [setIsOpen]
+  );
+
+  useEffect(() => {
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [handleClickOutside]);
+
+  const handleSelect = useCallback(
+    (time: string | null) => {
+      if (!time) {
+        setIsOpen(false);
+        return;
+      }
+
+      if (onChange) {
+        onChange({ target: { value: time } } as React.ChangeEvent<HTMLInputElement>);
+      }
+      setIsOpen(false);
+    },
+    [onChange, setIsOpen]
+  );
+
   const beforeIconStyle = "text-grayscale-400 size-5 lg:size-8";
-  const afterIconStyle =
-    "text-black-400 size-6 lg:size-9  transition-all transition-transform duration-200 ease-in-out";
+  const afterIconStyle = "text-black-400 size-6 lg:size-9 transition-transform duration-200 ease-in-out";
   const width = "w-[150px] lg:w-[210px]";
 
   const timeOption = Array.from({ length: 24 }, (_, index) => {
@@ -27,32 +53,42 @@ const TimePickerInput = forwardRef<HTMLInputElement, BaseInputProps>((props, ref
     return `${hour}:00`;
   });
 
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      handleOpenDropdown();
+    },
+    [handleOpenDropdown]
+  );
+
   return (
-    <div onClick={handleOpenDropdown} className="relative">
-      <div>{isOpen}</div>
-      <BaseInput
-        ref={ref}
-        type="text"
-        readOnly={true}
-        variant="white"
-        placeholder="00:00"
-        value={value || ""}
-        size="w-[150px] h-[54px] lg:w-[210px] lg:h-[64px]"
-        beforeIcon={<LuClock className={beforeIconStyle} strokeWidth="1" />}
-        afterIcon={<IoMdArrowDropup className={`${afterIconStyle} ${isOpen ? "rotate-180" : ""}`} />}
-        errormessage={errormessage}
-      />
+    <div ref={dropdownRef} className="relative">
+      <div onClick={handleClick}>
+        <BaseInput
+          ref={ref}
+          type="text"
+          readOnly
+          variant="white"
+          placeholder="00:00"
+          value={value || ""}
+          size="w-[150px] h-[54px] lg:w-[210px] lg:h-[64px]"
+          beforeIcon={<LuClock className={beforeIconStyle} strokeWidth="1" />}
+          afterIcon={<IoMdArrowDropup className={cn(afterIconStyle, isOpen && "rotate-180")} />}
+          errormessage={errormessage}
+        />
+      </div>
       {isOpen && (
         <DropdownList
           list={timeOption}
-          onSelect={handleTimeSelect}
+          onSelect={handleSelect}
           wrapperStyle={width}
-          itemStyle="pl-[35px] text-base font-normal leading-[26px] lg:text-lg lg:leading-8 !important"
+          itemStyle="pl-[35px] text-base font-normal leading-[26px] lg:text-lg lg:leading-8"
         />
       )}
     </div>
   );
 });
+
 TimePickerInput.displayName = "TimePickerInput";
 
 export default TimePickerInput;

--- a/src/app/components/layout/forms/SearchSection.tsx
+++ b/src/app/components/layout/forms/SearchSection.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import SearchInput from "@/app/components/input/text/SearchInput";
 import Button from "../../button/default/Button";
 
-export default function SearchSection() {
+export default function SearchSection({ pathname }: { pathname: string }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [keyword, setKeyword] = useState(searchParams.get("keyword") || "");
@@ -20,7 +20,7 @@ export default function SearchSection() {
       params.delete("keyword");
     }
 
-    router.push(`/albalist?${params.toString()}`);
+    router.push(`${pathname}?${params.toString()}`);
   };
 
   return (

--- a/src/hooks/useDropdownOpen.ts
+++ b/src/hooks/useDropdownOpen.ts
@@ -1,13 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useCallback } from "react";
 
 export const useDropdownOpen = () => {
-  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [isOpen, setIsOpen] = useState(false);
 
-  const handleOpenDropdown = (): void => {
-    setIsOpen(!isOpen);
-  };
+  const handleOpenDropdown = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
 
-  return { isOpen, handleOpenDropdown };
+  return { isOpen, setIsOpen, handleOpenDropdown };
 };

--- a/src/hooks/useDropdownOpen.ts
+++ b/src/hooks/useDropdownOpen.ts
@@ -2,9 +2,11 @@
 
 import { useState, useCallback } from "react";
 
+// 드롭다운 메뉴의 열림/닫힘 상태를 관리하는 커스텀 훅
 export const useDropdownOpen = () => {
   const [isOpen, setIsOpen] = useState(false);
 
+  // 드롭다운 메뉴 토글 핸들러
   const handleOpenDropdown = useCallback(() => {
     setIsOpen((prev) => !prev);
   }, []);


### PR DESCRIPTION
### 주요 변경사항
1. FilterDropdown
 - handleSelect 함수에서 null 체크 추가
 - 버튼 클릭 이벤트에 preventDefault 추가
 - 외부 클릭 시 드롭다운만 닫히도록 수정

2. DropdownList
 - DropdownItem의 클릭 핸들러에 stopPropagation 추가
 - 이벤트 전파 방지 로직 강화

3. InputDropdown
 - handleInputClick 함수 추가
 - input의 onClick 이벤트에 handleInputClick 연결
 - 이벤트 전파 방지와 함께 드롭다운 직접 열기

4. TimePickerInput
 - seCallback 추가하여 함수 메모이제이션
 - cn 유틸리티 추가 및 사용
 - readOnly={true}를 readOnly로 단순화
 - 불필요한 !important 제거
 - 이벤트 핸들러 의존성 배열 추가
 - 클래스네임 문자열 정리
 
5. useDropdownOpen 
 - Dispatch와 SetStateAction 타입 import 추가
 - setIsOpen 호출 시 함수형 업데이트 사용
 - 타입 명시적 지정 (prev: boolean)
 
6.  SearchSection
 - pathname 추가 및 연동

### 수정 후 해결된 문제
1. 더블 클릭 시 빈 메뉴가 생기는 현상이 해결됨
2. 이벤트 전파가 적절히 제어됨
3. 드롭다운이 더 안정적으로 동작함