### PR TITLE
Refactor : 폼작성 페이지에서 달력 인풋 데이터 불러오기

### DIFF
--- a/src/app/(pages)/(albaform)/addform/page.tsx
+++ b/src/app/(pages)/(albaform)/addform/page.tsx
@@ -224,12 +224,12 @@ export default function AddFormPage() {
   // 유저 권한 확인
   const { user, isLoading } = useUser();
 
-  // useEffect(() => {
-  //   if (user?.role !== "OWNER") {
-  //     toast.error("사장님만 워크폼을 작성할 수 있습니다.");
-  //     router.push("/alba-list");
-  //   }
-  // }, [user, router]);
+  useEffect(() => {
+    if (user?.role !== "OWNER") {
+      toast.error("사장님만 워크폼을 작성할 수 있습니다.");
+      router.push("/alba-list");
+    }
+  }, [user, router]);
 
   if (isLoading) {
     return <LoadingSpinner />;

--- a/src/app/(pages)/(albaform)/addform/page.tsx
+++ b/src/app/(pages)/(albaform)/addform/page.tsx
@@ -224,12 +224,12 @@ export default function AddFormPage() {
   // 유저 권한 확인
   const { user, isLoading } = useUser();
 
-  useEffect(() => {
-    if (user?.role !== "OWNER") {
-      toast.error("사장님만 워크폼을 작성할 수 있습니다.");
-      router.push("/alba-list");
-    }
-  }, [user, router]);
+  // useEffect(() => {
+  //   if (user?.role !== "OWNER") {
+  //     toast.error("사장님만 워크폼을 작성할 수 있습니다.");
+  //     router.push("/alba-list");
+  //   }
+  // }, [user, router]);
 
   if (isLoading) {
     return <LoadingSpinner />;

--- a/src/app/(pages)/(albaform)/addform/section/RecruitConditionSection.tsx
+++ b/src/app/(pages)/(albaform)/addform/section/RecruitConditionSection.tsx
@@ -30,14 +30,14 @@ export default function RecruitConditionSection() {
         <Label>학력</Label>
         <InputDropdown
           {...register("education", { required: "학력을 선택해주세요" })}
-          options={["고등학교 졸업", "대학교 졸업", "대학교 졸업 예정", "대학원 졸업", "학력 무관", "직접 입력"]}
+          options={["학력 무관", "고등학교 졸업", "대학교 졸업", "대학교 졸업 예정", "대학원 졸업", "직접 입력"]}
           errormessage={errors.education?.message as string}
         />
 
         <Label>연령</Label>
         <InputDropdown
           {...register("age", { required: "연령을 선택해주세요" })}
-          options={["10대", "20대", "30대", "40대", "50대", "60대", "연령 무관", "직접 입력"]}
+          options={["연령 무관", "10대", "20대", "30대", "40대", "50대", "60대", "직접 입력"]}
           errormessage={errors.age?.message as string}
         />
 

--- a/src/app/(pages)/(albaform)/addform/section/RecruitContentSection.tsx
+++ b/src/app/(pages)/(albaform)/addform/section/RecruitContentSection.tsx
@@ -101,6 +101,7 @@ export default function RecruitContentSection() {
 
   useEffect(() => {
     if (recruitStartDate !== "" && recruitEndDate !== "") setRecruitmentDateRange([StartDate, EndDate]);
+    console.log("section에서 날짜 출력", recruitmentDateRange);
   }, [recruitStartDate, recruitEndDate]);
 
   useEffect(() => {

--- a/src/app/(pages)/(albaform)/addform/section/RecruitContentSection.tsx
+++ b/src/app/(pages)/(albaform)/addform/section/RecruitContentSection.tsx
@@ -79,15 +79,30 @@ export default function RecruitContentSection() {
     }
   }, [imageUrlsData]);
 
-  // 훅폼에서 recruitment Start/End Data 가져와서 recruitmentDateRange에 반영하기
+  // 모집 기간 데이터 반영하기
   const recruitStartDate: string = watch("recruitmentStartDate");
   const recruitEndDate: string = watch("recruitmentEndDate");
-  const StartDate = new Date(recruitStartDate) || null;
-  const EndDate = new Date(recruitEndDate) || null;
+  const StartDate =
+    recruitStartDate === "" || recruitStartDate === undefined || recruitStartDate === null
+      ? null
+      : new Date(recruitStartDate);
+  const EndDate =
+    recruitEndDate === "" || recruitEndDate === undefined || recruitEndDate === null ? null : new Date(recruitEndDate);
+
+  useEffect(() => {
+    if (StartDate && EndDate) setRecruitmentDateRange([StartDate, EndDate]);
+  }, [recruitStartDate, recruitEndDate]);
 
   // displayRange를 상위에서 관리
-  const displayDate = `${formatToLocaleDate(recruitStartDate)} ~ ${formatToLocaleDate(recruitEndDate)}`;
+  const displayDate =
+    recruitStartDate === "" || recruitStartDate === undefined || recruitStartDate === null
+      ? ""
+      : `${formatToLocaleDate(recruitStartDate)} ~ ${formatToLocaleDate(recruitEndDate)}`;
   const [displayRange, setDisplayRange] = useState<string>(displayDate || "");
+
+  useEffect(() => {
+    setDisplayRange(displayDate);
+  }, [recruitStartDate, recruitEndDate, displayDate]);
 
   // 날짜 선택
   const [recruitmentDateRange, setRecruitmentDateRange] = useState<[Date | null, Date | null]>([null, null]);
@@ -98,15 +113,6 @@ export default function RecruitContentSection() {
     if (start) setValue("recruitmentStartDate", start.toISOString());
     if (end) setValue("recruitmentEndDate", end.toISOString(), { shouldDirty: true });
   };
-
-  useEffect(() => {
-    if (recruitStartDate !== "" && recruitEndDate !== "") setRecruitmentDateRange([StartDate, EndDate]);
-    console.log("section에서 날짜 출력", recruitmentDateRange);
-  }, [recruitStartDate, recruitEndDate]);
-
-  useEffect(() => {
-    setDisplayRange(displayDate);
-  }, [recruitStartDate, recruitEndDate]);
 
   const errorTextStyle =
     "absolute -bottom-[26px] right-1 text-[13px] text-sm font-medium leading-[22px] text-state-error lg:text-base lg:leading-[26px]";

--- a/src/app/(pages)/(albaform)/addform/section/RecruitContentSection.tsx
+++ b/src/app/(pages)/(albaform)/addform/section/RecruitContentSection.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from "react";
 import Label from "../../component/Label";
 import { ImageInputType } from "@/types/addform";
 import useUploadImages from "@/hooks/queries/user/me/useImageUpload";
+import { formatToLocaleDate } from "@/utils/formatters";
 
 // 워크폼 만들기 - 사장님 - 1-모집내용
 
@@ -92,10 +93,17 @@ export default function RecruitContentSection() {
   const recruitEndDate: string = watch("recruitmentEndDate");
   const StartDate = new Date(recruitStartDate);
   const EndDate = new Date(recruitEndDate);
-  // const displayDate = `${StartDate} ~ ${EndDate}`;
 
   useEffect(() => {
     if (recruitStartDate !== "" && recruitEndDate !== "") setRecruitmentDateRange([StartDate, EndDate]);
+  }, [recruitStartDate, recruitEndDate]);
+
+  // displayRange를 상위에서 관리
+  const displayDate = `${formatToLocaleDate(recruitStartDate)} ~ ${formatToLocaleDate(recruitEndDate)}`;
+  const [displayRange, setDisplayRange] = useState<string>(displayDate || "");
+
+  useEffect(() => {
+    setDisplayRange(displayDate);
   }, [recruitStartDate, recruitEndDate]);
 
   const errorTextStyle =
@@ -134,7 +142,7 @@ export default function RecruitContentSection() {
             onChange={handleRecruitmentDateChange}
             required={true}
             errormessage={!recruitmentDateRange[0] || !recruitmentDateRange[1]}
-            displayValue="recruitDateRange"
+            displayValue={displayRange}
           />
           {!recruitmentDateRange[0] ||
             (!recruitmentDateRange[1] && <p className={cn(errorTextStyle, "")}> 모집 기간은 필수입니다.</p>)}

--- a/src/app/(pages)/(albaform)/addform/section/RecruitContentSection.tsx
+++ b/src/app/(pages)/(albaform)/addform/section/RecruitContentSection.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from "react";
 import Label from "../../component/Label";
 import { ImageInputType } from "@/types/addform";
 import useUploadImages from "@/hooks/queries/user/me/useImageUpload";
+import { formatDate } from "@/utils/formatters";
 
 // 알바폼 만들기 - 사장님 - 1-모집내용
 
@@ -86,6 +87,19 @@ export default function RecruitContentSection() {
     if (start) setValue("recruitmentStartDate", start.toISOString());
     if (end) setValue("recruitmentEndDate", end.toISOString());
   };
+
+  // 훅폼에서 recruitment Start/End Data 가져와서 recruitmentDateRange에 반영하기
+  // iso -> locale로 수정하기
+  const recruitStartDate: string = watch("recruitmentStartDate");
+  const recruitEndDate: string = watch("recruitmentEndDate");
+  const StartDate = new Date(recruitStartDate);
+  const EndDate = new Date(recruitEndDate);
+  // const displayDate = `${StartDate} ~ ${EndDate}`;
+
+  useEffect(() => {
+    if (recruitStartDate !== "" && recruitEndDate !== "") setRecruitmentDateRange([StartDate, EndDate]);
+  }, [recruitStartDate, recruitEndDate]);
+
   const errorTextStyle =
     "absolute -bottom-[26px] right-1 text-[13px] text-sm font-medium leading-[22px] text-state-error lg:text-base lg:leading-[26px]";
 

--- a/src/app/(pages)/(albaform)/addform/section/RecruitContentSection.tsx
+++ b/src/app/(pages)/(albaform)/addform/section/RecruitContentSection.tsx
@@ -9,7 +9,6 @@ import { useEffect, useState } from "react";
 import Label from "../../component/Label";
 import { ImageInputType } from "@/types/addform";
 import useUploadImages from "@/hooks/queries/user/me/useImageUpload";
-import { formatDate } from "@/utils/formatters";
 
 // 알바폼 만들기 - 사장님 - 1-모집내용
 
@@ -89,7 +88,6 @@ export default function RecruitContentSection() {
   };
 
   // 훅폼에서 recruitment Start/End Data 가져와서 recruitmentDateRange에 반영하기
-  // iso -> locale로 수정하기
   const recruitStartDate: string = watch("recruitmentStartDate");
   const recruitEndDate: string = watch("recruitmentEndDate");
   const StartDate = new Date(recruitStartDate);

--- a/src/app/(pages)/(albaform)/addform/section/RecruitContentSection.tsx
+++ b/src/app/(pages)/(albaform)/addform/section/RecruitContentSection.tsx
@@ -79,28 +79,29 @@ export default function RecruitContentSection() {
     }
   }, [imageUrlsData]);
 
-  // 날짜 선택
-  const [recruitmentDateRange, setRecruitmentDateRange] = useState<[Date | null, Date | null]>([null, null]);
-  const handleRecruitmentDateChange = (dates: [Date | null, Date | null]) => {
-    setRecruitmentDateRange(dates);
-    const [start, end] = dates;
-    if (start) setValue("recruitmentStartDate", start.toISOString());
-    if (end) setValue("recruitmentEndDate", end.toISOString());
-  };
-
   // 훅폼에서 recruitment Start/End Data 가져와서 recruitmentDateRange에 반영하기
   const recruitStartDate: string = watch("recruitmentStartDate");
   const recruitEndDate: string = watch("recruitmentEndDate");
-  const StartDate = new Date(recruitStartDate);
-  const EndDate = new Date(recruitEndDate);
-
-  useEffect(() => {
-    if (recruitStartDate !== "" && recruitEndDate !== "") setRecruitmentDateRange([StartDate, EndDate]);
-  }, [recruitStartDate, recruitEndDate]);
+  const StartDate = new Date(recruitStartDate) || null;
+  const EndDate = new Date(recruitEndDate) || null;
 
   // displayRange를 상위에서 관리
   const displayDate = `${formatToLocaleDate(recruitStartDate)} ~ ${formatToLocaleDate(recruitEndDate)}`;
   const [displayRange, setDisplayRange] = useState<string>(displayDate || "");
+
+  // 날짜 선택
+  const [recruitmentDateRange, setRecruitmentDateRange] = useState<[Date | null, Date | null]>([null, null]);
+
+  const handleRecruitmentDateChange = (dates: [Date | null, Date | null]) => {
+    setRecruitmentDateRange(dates); // -> prop으로 내려줌
+    const [start, end] = dates;
+    if (start) setValue("recruitmentStartDate", start.toISOString());
+    if (end) setValue("recruitmentEndDate", end.toISOString(), { shouldDirty: true });
+  };
+
+  useEffect(() => {
+    if (recruitStartDate !== "" && recruitEndDate !== "") setRecruitmentDateRange([StartDate, EndDate]);
+  }, [recruitStartDate, recruitEndDate]);
 
   useEffect(() => {
     setDisplayRange(displayDate);
@@ -135,8 +136,6 @@ export default function RecruitContentSection() {
         <div className="relative flex flex-col gap-2">
           <Label>모집 기간</Label>
           <DatePickerInput
-            startDateName="recruitmentStartDate"
-            endDateName="recruitmentEndDate"
             startDate={recruitmentDateRange[0] || undefined}
             endDate={recruitmentDateRange[1] || undefined}
             onChange={handleRecruitmentDateChange}

--- a/src/app/(pages)/(albaform)/addform/section/WorkConditionSection.tsx
+++ b/src/app/(pages)/(albaform)/addform/section/WorkConditionSection.tsx
@@ -126,8 +126,6 @@ export default function WorkConditionSection() {
         <div className="relative flex flex-col gap-2">
           <Label>근무 기간</Label>
           <DatePickerInput
-            startDateName="workStartDate"
-            endDateName="workEndDate"
             startDate={workDateRange[0] || undefined}
             endDate={workDateRange[1] || undefined}
             onChange={handleWorkDateChange}

--- a/src/app/(pages)/(albaform)/addform/section/WorkConditionSection.tsx
+++ b/src/app/(pages)/(albaform)/addform/section/WorkConditionSection.tsx
@@ -12,7 +12,6 @@ import formatMoney from "@/utils/formatMoney";
 import Label from "../../component/Label";
 import Script from "next/script";
 import LocationInput from "@/app/components/input/text/LocationInput";
-import { toast } from "react-hot-toast";
 
 // 알바폼 만들기 - 사장님 - 3-근무조건
 export default function WorkConditionSection() {
@@ -32,6 +31,16 @@ export default function WorkConditionSection() {
     if (start) setValue("workStartDate", start.toISOString());
     if (end) setValue("workEndDate", end.toISOString());
   };
+
+  // 근무 기간 데이터 반영하기
+  const workStartDate: string = watch("workStartDate");
+  const workEndDate: string = watch("workEndDate");
+  const StartDate = new Date(workStartDate);
+  const EndDate = new Date(workEndDate);
+
+  useEffect(() => {
+    if (workStartDate !== "" && workEndDate !== "") setWorkDateRange([StartDate, EndDate]);
+  }, [workStartDate, workEndDate]);
 
   //근무 시간 지정
   const workStartTime = watch("workStartTime");

--- a/src/app/(pages)/(albaform)/addform/section/WorkConditionSection.tsx
+++ b/src/app/(pages)/(albaform)/addform/section/WorkConditionSection.tsx
@@ -59,7 +59,7 @@ export default function WorkConditionSection() {
   };
 
   //근무 시간 지정
-  const workStartTime = watch("workStartTime");
+  const workStartTime = watch("workStartTime") || "06:00";
   const workEndTime = watch("workEndTime");
 
   //근무 요일 지정

--- a/src/app/(pages)/(albaform)/addform/section/WorkConditionSection.tsx
+++ b/src/app/(pages)/(albaform)/addform/section/WorkConditionSection.tsx
@@ -12,6 +12,7 @@ import formatMoney from "@/utils/formatMoney";
 import Label from "../../component/Label";
 import Script from "next/script";
 import LocationInput from "@/app/components/input/text/LocationInput";
+import { formatToLocaleDate } from "@/utils/formatters";
 
 // 워크폼 만들기 - 사장님 - 3-근무조건
 export default function WorkConditionSection() {
@@ -40,6 +41,14 @@ export default function WorkConditionSection() {
 
   useEffect(() => {
     if (workStartDate !== "" && workEndDate !== "") setWorkDateRange([StartDate, EndDate]);
+  }, [workStartDate, workEndDate]);
+
+  // displayRange를 상위에서 관리
+  const displayDate = `${formatToLocaleDate(workStartDate)} ~ ${formatToLocaleDate(workEndDate)}`;
+  const [displayRange, setDisplayRange] = useState<string>(displayDate || "");
+
+  useEffect(() => {
+    setDisplayRange(displayDate);
   }, [workStartDate, workEndDate]);
 
   //근무 시간 지정
@@ -124,7 +133,7 @@ export default function WorkConditionSection() {
             onChange={handleWorkDateChange}
             required={true}
             errormessage={!workDateRange[0] || !workDateRange[1]}
-            displayValue="workDateRange"
+            displayValue={displayRange}
           />
           {!workDateRange[0] ||
             (!workDateRange[1] && <p className={cn(errorTextStyle, "")}> 근무 기간은 필수입니다.</p>)}

--- a/src/app/(pages)/(albaform)/addform/section/WorkConditionSection.tsx
+++ b/src/app/(pages)/(albaform)/addform/section/WorkConditionSection.tsx
@@ -77,6 +77,14 @@ export default function WorkConditionSection() {
     }
   };
 
+  const workdaysData = watch("workDays");
+  const isNegotiable = watch("isNegotiableWorkDays");
+  useEffect(() => {
+    if (!isNegotiable && workdaysData.length > 0) {
+      setSelectedWorkDays(workdaysData);
+    }
+  }, [workdaysData]);
+
   // 최저시급 상수 수정 (2025년 기준)
   const MINIMUM_WAGE = 10030;
 

--- a/src/app/(pages)/(albaform)/addform/section/WorkConditionSection.tsx
+++ b/src/app/(pages)/(albaform)/addform/section/WorkConditionSection.tsx
@@ -24,20 +24,13 @@ export default function WorkConditionSection() {
     formState: { errors },
   } = useFormContext();
 
-  // 근무 날짜 지정
-  const [workDateRange, setWorkDateRange] = useState<[Date | null, Date | null]>([null, null]);
-  const handleWorkDateChange = (dates: [Date | null, Date | null]) => {
-    setWorkDateRange(dates);
-    const [start, end] = dates;
-    if (start) setValue("workStartDate", start.toISOString());
-    if (end) setValue("workEndDate", end.toISOString());
-  };
-
   // 근무 기간 데이터 반영하기
   const workStartDate: string = watch("workStartDate");
   const workEndDate: string = watch("workEndDate");
-  const StartDate = new Date(workStartDate);
-  const EndDate = new Date(workEndDate);
+  const StartDate =
+    workStartDate === "" || workStartDate === undefined || workStartDate === null ? null : new Date(workStartDate);
+  const EndDate =
+    workEndDate === "" || workEndDate === undefined || workEndDate === null ? null : new Date(workEndDate);
 
   useEffect(() => {
     if (workStartDate !== "" && workEndDate !== "") setWorkDateRange([StartDate, EndDate]);
@@ -45,11 +38,25 @@ export default function WorkConditionSection() {
 
   // displayRange를 상위에서 관리
   const displayDate = `${formatToLocaleDate(workStartDate)} ~ ${formatToLocaleDate(workEndDate)}`;
-  const [displayRange, setDisplayRange] = useState<string>(displayDate || "");
+  const [displayRange, setDisplayRange] = useState<string>("");
 
   useEffect(() => {
-    setDisplayRange(displayDate);
-  }, [workStartDate, workEndDate]);
+    if (formatToLocaleDate(workStartDate)?.includes("NaN")) {
+      setDisplayRange("");
+    } else {
+      setDisplayRange(displayDate);
+    }
+  }, [workStartDate, workEndDate, displayDate]);
+
+  // 날짜 선택
+  const [workDateRange, setWorkDateRange] = useState<[Date | null, Date | null]>([null, null]);
+
+  const handleWorkDateChange = (dates: [Date | null, Date | null]) => {
+    setWorkDateRange(dates);
+    const [start, end] = dates;
+    if (start) setValue("workStartDate", start.toISOString());
+    if (end) setValue("workEndDate", end.toISOString(), { shouldDirty: true });
+  };
 
   //근무 시간 지정
   const workStartTime = watch("workStartTime");

--- a/src/app/(pages)/(albaform)/alba/[formId]/edit/page.tsx
+++ b/src/app/(pages)/(albaform)/alba/[formId]/edit/page.tsx
@@ -99,14 +99,14 @@ export default function EditFormPage() {
             acc[key] = Number(value);
           } else if (key === "hourlyWage") {
             // hourlyWage는 쉼표를 제거하고 숫자형으로 변환
-            if (value.includes(",")) acc[key] = String(Number(value.replaceAll(/,/g, ""))); // 쉼표 제거 후 숫자형 변환
+            if (typeof value === "string" && value.includes(",")) acc[key] = String(Number(value.replaceAll(/,/g, ""))); // 쉼표 제거 후 숫자형 변환
           } else {
             acc[key as keyof SubmitFormDataType] = value; // 나머지 값은 그대로 추가
           }
           return acc;
         }, {});
-      await axios.patch(`/api/forms/${formId}`, filteredData);
       console.log("filteredData", filteredData);
+      await axios.patch(`/api/forms/${formId}`, filteredData);
     },
     onSuccess: () => {
       if (typeof window !== "undefined") {

--- a/src/app/(pages)/(albaform)/layout.tsx
+++ b/src/app/(pages)/(albaform)/layout.tsx
@@ -28,47 +28,48 @@ export default function Layout({ children }: { children: ReactNode }) {
   const DetailStyle = "mx-auto max-w-screen-xl  px-4 py-4 sm:px-6 md:py-8 justify-center flex";
 
   return (
-    <div className={cn(isForm ? FormStyle : DetailStyle)}>
-      {isForm && (
-        <ApplyHeader
-          title={title}
-          onCancel={() =>
-            openModal("customForm", {
-              isOpen: true,
-              title: "폼 작성 취소",
-              content: "작성을 취소하시겠습니까?",
-              onConfirm: () => {
-                openModal("customForm", {
-                  isOpen: false,
-                  title: "",
-                  content: "",
-                  onConfirm: () => {},
-                  onCancel: () => {},
-                });
-                router.back();
-              },
-              onCancel: () => {
-                openModal("customForm", {
-                  isOpen: false,
-                  title: "",
-                  content: "",
-                  onConfirm: () => {},
-                  onCancel: () => {},
-                });
-              },
-            })
-          }
-        />
-      )}
-      <Suspense
-        fallback={
-          <div className="flex h-[calc(100vh-200px)] items-center justify-center">
-            <LoadingSpinner />
-          </div>
-        }
-      >
+    <Suspense
+      fallback={
+        <div className="flex h-[calc(100vh-200px)] items-center justify-center">
+          <LoadingSpinner />
+        </div>
+      }
+    >
+      <div className={cn(isForm ? FormStyle : DetailStyle)}>
+        {isForm && (
+          <ApplyHeader
+            title={title}
+            onCancel={() =>
+              openModal("customForm", {
+                isOpen: true,
+                title: "폼 작성 취소",
+                content: "작성을 취소하시겠습니까?",
+                onConfirm: () => {
+                  openModal("customForm", {
+                    isOpen: false,
+                    title: "",
+                    content: "",
+                    onConfirm: () => {},
+                    onCancel: () => {},
+                  });
+                  router.back();
+                },
+                onCancel: () => {
+                  openModal("customForm", {
+                    isOpen: false,
+                    title: "",
+                    content: "",
+                    onConfirm: () => {},
+                    onCancel: () => {},
+                  });
+                },
+              })
+            }
+          />
+        )}
+
         {children}
-      </Suspense>
-    </div>
+      </div>
+    </Suspense>
   );
 }

--- a/src/app/components/button/dropdown/TabMenuDropdown.tsx
+++ b/src/app/components/button/dropdown/TabMenuDropdown.tsx
@@ -19,9 +19,9 @@ const EditingChip = ({ className = "", selected }: { className?: string; selecte
 };
 
 const TabMenuDropdown = ({ options, className = "", onChange, currentParam = "" }: TopMenuDropdownProps) => {
-  const [isOpen, setIsOpen] = useState<boolean>(false);
-  const [selectedLabel, setSelectedLabel] = useState<string>(options[0].label); // 선택된 값 (label을 저장)
   const { isDesktop } = useWidth();
+  const [isOpen, setIsOpen] = useState<boolean>(isDesktop);
+  const [selectedLabel, setSelectedLabel] = useState<string>(options[0].label); // 선택된 값 (label을 저장)
 
   useEffect(() => {
     switch (currentParam) {
@@ -38,6 +38,10 @@ const TabMenuDropdown = ({ options, className = "", onChange, currentParam = "" 
         setSelectedLabel("모집 내용");
     }
   }, []);
+
+  useEffect(() => {
+    setIsOpen(isDesktop);
+  }, [isDesktop]);
 
   const handleOptionClick = (label: string) => {
     setSelectedLabel(label); // 선택된 레이블을 저장

--- a/src/app/components/input/dateTimeDaypicker/DatePickerInput.tsx
+++ b/src/app/components/input/dateTimeDaypicker/DatePickerInput.tsx
@@ -47,7 +47,6 @@ const DatePickerInput = ({
       handleOpenDropdown();
     }
     onChange(newDateRange);
-    console.log("인풋 컴포넌트에서 - ", start, end);
   };
 
   //피커 바깥쪽 클릭 시 창 닫힘

--- a/src/app/components/input/dateTimeDaypicker/DatePickerInput.tsx
+++ b/src/app/components/input/dateTimeDaypicker/DatePickerInput.tsx
@@ -26,6 +26,12 @@ const DatePickerInput = ({
 }: DatePickerInputProps) => {
   const { isOpen, handleOpenDropdown } = useDropdownOpen();
 
+  const handleClick = () => {
+    if (endDate) {
+      onChange([null, null]);
+    }
+    handleOpenDropdown();
+  };
   const handleChange = (update: [Date | null, Date | null]) => {
     // 날짜를 선택하면 onChange 호출 -> 상위로 전달
     const [start, end] = update;
@@ -63,7 +69,7 @@ const DatePickerInput = ({
 
   return (
     <div className="relative">
-      <div onClick={handleOpenDropdown}>
+      <div onClick={handleClick}>
         <BaseInput
           type="text"
           placeholder="시작일 ~ 종료일"

--- a/src/app/components/input/dateTimeDaypicker/DatePickerInput.tsx
+++ b/src/app/components/input/dateTimeDaypicker/DatePickerInput.tsx
@@ -29,16 +29,16 @@ const DatePickerInput = ({
   const handleChange = (update: [Date | null, Date | null]) => {
     // 날짜를 선택하면 onChange 호출 -> 상위로 전달
     const [start, end] = update;
-    let newDateRange: [Date | null, Date | null] = [startDate || null, endDate || null];
+    let newDateRange: [Date | null, Date | null] = [start || null, end || null];
     // 시작 날짜가 설정되지 않았거나, 종료 날짜가 선택되지 않은 경우 처리
-    if (start && (!end || end <= start)) {
-      newDateRange = [start, null]; // 시작 날짜만 설정
+    if (start && end && end < start) {
+      newDateRange = [start, null];
     }
 
     // 시작 날짜와 종료 날짜가 올바르게 선택된 경우
     if (start && end && end > start) {
       newDateRange = [start, end]; // 시작 및 종료 날짜 설정
-      handleOpenDropdown(); // 드롭다운 닫기
+      handleOpenDropdown();
     }
     onChange(newDateRange);
     console.log("인풋 컴포넌트에서 - ", start, end);

--- a/src/app/components/input/dateTimeDaypicker/DatePickerInput.tsx
+++ b/src/app/components/input/dateTimeDaypicker/DatePickerInput.tsx
@@ -29,39 +29,18 @@ const DatePickerInput = ({
   errormessage,
   displayValue,
 }: DatePickerInputProps) => {
-  const { setValue, watch } = useFormContext();
+  const { setValue } = useFormContext();
   const { isOpen, handleOpenDropdown } = useDropdownOpen();
-  const dateValue = watch(displayValue);
-
-  useEffect(() => {
-    const currentValue = watch(displayValue);
-    if (currentValue) {
-      setValue(displayValue, currentValue);
-    }
-  }, [displayValue, watch, setValue]);
 
   const iconStyle = "text-black-400 size-9 transition-transform duration-200";
-
-  const formatDisplayDate = (start: Date, end?: Date) => {
-    const formatToDisplay = (date: Date) => {
-      return `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, "0")}/${date.getDate().toString().padStart(2, "0")}`;
-    };
-
-    if (start && end) {
-      return `${formatToDisplay(start)} ~ ${formatToDisplay(end)}`;
-    }
-    return formatToDisplay(start);
-  };
 
   const handleChange = (update: [Date | null, Date | null]) => {
     const [start, end] = update;
 
     if (start) {
-      setValue(displayValue, formatDisplayDate(start, end || undefined));
       setValue(startDateName, start.toISOString());
     }
     if (start && end && end > start) {
-      setValue(displayValue, formatDisplayDate(start, end));
       setValue(endDateName, end.toISOString());
       handleOpenDropdown();
     }
@@ -92,7 +71,7 @@ const DatePickerInput = ({
           variant="white"
           beforeIcon={<BsCalendar4 className="size-4 text-grayscale-200 lg:size-8" />}
           afterIcon={<IoMdArrowDropup className={`${iconStyle} ${isOpen ? "rotate-180" : ""}`} />}
-          value={dateValue || ""}
+          value={displayValue || ""}
           readOnly
           required={required}
           wrapperClassName="cursor-pointer"

--- a/src/app/components/input/dateTimeDaypicker/DatePickerInput.tsx
+++ b/src/app/components/input/dateTimeDaypicker/DatePickerInput.tsx
@@ -6,12 +6,9 @@ import { ko } from "date-fns/locale";
 import { IoIosClose, IoMdArrowDropup } from "react-icons/io";
 import { BsCalendar4 } from "react-icons/bs";
 import { useDropdownOpen } from "@/hooks/useDropdownOpen";
-import { useFormContext } from "react-hook-form";
 import DatePickerHeader from "./DatePickerHeader";
 import { useEffect, useRef } from "react";
 interface DatePickerInputProps {
-  startDateName: string;
-  endDateName: string;
   startDate?: Date;
   endDate?: Date;
   onChange: (dates: [Date | null, Date | null]) => void;
@@ -20,8 +17,6 @@ interface DatePickerInputProps {
   displayValue: string;
 }
 const DatePickerInput = ({
-  startDateName,
-  endDateName,
   startDate,
   endDate,
   onChange,
@@ -29,22 +24,24 @@ const DatePickerInput = ({
   errormessage,
   displayValue,
 }: DatePickerInputProps) => {
-  const { setValue } = useFormContext();
   const { isOpen, handleOpenDropdown } = useDropdownOpen();
 
-  const iconStyle = "text-black-400 size-9 transition-transform duration-200";
-
   const handleChange = (update: [Date | null, Date | null]) => {
+    // 날짜를 선택하면 onChange 호출 -> 상위로 전달
     const [start, end] = update;
+    let newDateRange: [Date | null, Date | null] = [startDate || null, endDate || null];
+    // 시작 날짜가 설정되지 않았거나, 종료 날짜가 선택되지 않은 경우 처리
+    if (start && (!end || end <= start)) {
+      newDateRange = [start, null]; // 시작 날짜만 설정
+    }
 
-    if (start) {
-      setValue(startDateName, start.toISOString());
-    }
+    // 시작 날짜와 종료 날짜가 올바르게 선택된 경우
     if (start && end && end > start) {
-      setValue(endDateName, end.toISOString());
-      handleOpenDropdown();
+      newDateRange = [start, end]; // 시작 및 종료 날짜 설정
+      handleOpenDropdown(); // 드롭다운 닫기
     }
-    onChange(update);
+    onChange(newDateRange);
+    console.log("인풋 컴포넌트에서 - ", start, end);
   };
 
   //피커 바깥쪽 클릭 시 창 닫힘
@@ -61,6 +58,8 @@ const DatePickerInput = ({
       window.removeEventListener("mousedown", handleClickOutside);
     };
   }, [handleOpenDropdown]);
+
+  const iconStyle = "text-black-400 size-9 transition-transform duration-200";
 
   return (
     <div className="relative">

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -14,12 +14,15 @@ export const formatDateTime = (date: string): string => {
 };
 
 export const formatToLocaleDate = (date: string): string => {
-  const d = new Date(date);
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1);
-  const day = String(d.getDate());
-
-  return `${year}/${month}/${day}`;
+  if (date !== undefined) {
+    const d = new Date(date);
+    const year = d.getFullYear();
+    const month = String(d.getMonth() + 1);
+    const day = String(d.getDate());
+    return `${year}/${month}/${day}`;
+  } else {
+    return "";
+  }
 };
 
 export const formatCurrency = (amount: number): string => {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -13,6 +13,15 @@ export const formatDateTime = (date: string): string => {
   return `${year}년 ${month}월 ${day}일 ${hours}:${minutes}`;
 };
 
+export const formatToLocaleDate = (date: string): string => {
+  const d = new Date(date);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1);
+  const day = String(d.getDate());
+
+  return `${year}/${month}/${day}`;
+};
+
 export const formatCurrency = (amount: number): string => {
   return new Intl.NumberFormat("ko-KR", {
     style: "currency",


### PR DESCRIPTION
## 작업 내용
### 모집 기간, 근무 기간, 근무 요일 : edit 페이지에서 데이터 가져와서 띄워주기
### 달력 컴포넌트 내에서 useFormContext 호출하지않고 상위에서 훅폼 데이터 관리하도록 함 
### 버그 해결 : 선택한 날짜 값이 있는 상태에서 달력 열면 기존 값 초기화 
- #167 